### PR TITLE
Upgrade to SDL3 and refactor input handling

### DIFF
--- a/Hexa.NET.KittyUI.WebView/CefHelper.cs
+++ b/Hexa.NET.KittyUI.WebView/CefHelper.cs
@@ -1,6 +1,6 @@
 ﻿namespace Hexa.NET.KittyUI.WebView
 {
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using System;
 
     public static class CefHelper

--- a/Hexa.NET.KittyUI.WebView/PopupWindow.cs
+++ b/Hexa.NET.KittyUI.WebView/PopupWindow.cs
@@ -12,7 +12,7 @@
 
     using Hexa.NET.KittyUI.D3D11;
     using Hexa.NET.KittyUI.Windows;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using Hexa.NET.KittyUI.Graphics;
 
     public unsafe class PopupWindow : CoreWindow

--- a/Hexa.NET.KittyUI.WebView/RenderHandlerBase.cs
+++ b/Hexa.NET.KittyUI.WebView/RenderHandlerBase.cs
@@ -5,7 +5,7 @@
     using CefSharp.OffScreen;
     using CefSharp.Structs;
     using Hexa.NET.ImGui;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using System.Collections.Concurrent;
 
     public abstract class RenderHandlerBase : IRenderHandler
@@ -141,7 +141,7 @@
 
         public virtual void OnVirtualKeyboardRequested(IBrowser browser, TextInputMode inputMode)
         {
-            if (SDL.HasScreenKeyboardSupport() == SDLBool.True)
+            if (SDL.HasScreenKeyboardSupport() == true)
             {
                 if (inputMode == TextInputMode.None)
                 {

--- a/Hexa.NET.KittyUI.WebView/WebView.cs
+++ b/Hexa.NET.KittyUI.WebView/WebView.cs
@@ -9,7 +9,7 @@
     using Hexa.NET.KittyUI.Input;
     using Hexa.NET.KittyUI.Windows;
     using Hexa.NET.Mathematics;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using System;
     using System.Numerics;
     using System.Runtime.CompilerServices;

--- a/Hexa.NET.KittyUI/Application.cs
+++ b/Hexa.NET.KittyUI/Application.cs
@@ -8,12 +8,13 @@
     using Hexa.NET.KittyUI.Windows;
     using Hexa.NET.KittyUI.Windows.Events;
     using Hexa.NET.Logging;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using System.Collections.Generic;
     using static Hexa.NET.KittyUI.Extensions.SdlErrorHandlingExtensions;
 
     public static unsafe class Application
     {
+        private static bool earlyInitialized = false;
         private static bool initialized = false;
         private static bool exiting = false;
         private static readonly Dictionary<uint, IRenderWindow> windowIdToWindow = new();
@@ -75,10 +76,12 @@
 
         public static LogFileWriter? FileLogWriter { get; set; }
 
-        public static uint InitFlags { get; set; } = SDL.SDL_INIT_GAMECONTROLLER + SDL.SDL_INIT_JOYSTICK;
-
-        private static void Init(IRenderWindow mainWindow, AppBuilder builder)
+        public static SDLInitFlags InitFlags { get; set; } = SDLInitFlags.Events | SDLInitFlags.Video | SDLInitFlags.Joystick | SDLInitFlags.Gamepad;
+        
+        internal static void EarlyInit()
         {
+            if (earlyInitialized) return;
+
             if (LoggingEnabled)
             {
                 FileLogWriter = new("logs");
@@ -86,6 +89,27 @@
                 LoggerFactory.AddGlobalWriter(FileLogWriter);
             }
 
+            SDL.SetHint(SDL.SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
+            SDL.SetHint(SDL.SDL_HINT_AUTO_UPDATE_JOYSTICKS, "1");
+            SDL.SetHint(SDL.SDL_HINT_JOYSTICK_HIDAPI_PS4, "1"); // HintJoystickHidapiPS4
+            SDL.SetHint(SDL.SDL_HINT_JOYSTICK_RAWINPUT, "0");
+            SDL.SetHint(SDL.SDL_HINT_MOUSE_NORMAL_SPEED_SCALE, "1");
+            SDL.SetHint(SDL.SDL_HINT_MOUSE_AUTO_CAPTURE, "0");
+
+            SDL.Init(InitFlags);
+
+            SdlCheckError();
+
+            Keyboard.Init();
+            Mouse.Init();
+            Gamepads.Init();
+            TouchDevices.Init();
+
+            earlyInitialized = true;
+        }
+
+        private static void Init(IRenderWindow mainWindow, AppBuilder builder)
+        {
             if (ImGuiDebugTools.Enabled)
             {
                 ImGuiDebugTools.Init();
@@ -96,25 +120,6 @@
 #if DEBUG
             GraphicsDebugging = true;
 #endif
-
-            SDL.SetHint(SDL.SDL_HINT_MOUSE_FOCUS_CLICKTHROUGH, "1");
-            SDL.SetHint(SDL.SDL_HINT_AUTO_UPDATE_JOYSTICKS, "1");
-            SDL.SetHint(SDL.SDL_HINT_JOYSTICK_HIDAPI_PS4, "1"); // HintJoystickHidapiPS4
-            SDL.SetHint(SDL.SDL_HINT_JOYSTICK_HIDAPI_PS4_RUMBLE, "1"); // HintJoystickHidapiPS4Rumble
-            SDL.SetHint(SDL.SDL_HINT_JOYSTICK_RAWINPUT, "0");
-            SDL.SetHint(SDL.SDL_HINT_WINDOWS_DISABLE_THREAD_NAMING, "1"); // HintWindowsDisableThreadNaming
-            SDL.SetHint(SDL.SDL_HINT_MOUSE_NORMAL_SPEED_SCALE, "1");
-            SDL.SetHint(SDL.SDL_HINT_MOUSE_AUTO_CAPTURE, "0");
-            SDL.SetHint(SDL.SDL_HINT_IME_SHOW_UI, "1");
-
-            SDL.Init(InitFlags);
-
-            SdlCheckError();
-
-            Keyboard.Init();
-            Mouse.Init();
-            Gamepads.Init();
-            TouchDevices.Init();
 
             if ((SubSystems & SubSystems.Audio) != 0)
             {
@@ -209,7 +214,7 @@
             while (!exiting)
             {
                 SDL.PumpEvents();
-                while (SDL.PollEvent(&evnt) == (int)SDLBool.True)
+                while (SDL.PollEvent(&evnt))
                 {
                     for (int i = 0; i < hooks.Count; i++)
                     {
@@ -245,9 +250,6 @@
         {
             switch (type)
             {
-                case SDLEventType.Firstevent:
-                    break;
-
                 case SDLEventType.Quit:
                     if (!supressQuitApp)
                     {
@@ -256,32 +258,29 @@
                     supressQuitApp = false;
                     break;
 
-                case SDLEventType.AppTerminating:
+                case SDLEventType.Terminating:
                     exiting = true;
                     break;
 
-                case SDLEventType.AppLowmemory:
+                case SDLEventType.LowMemory:
                     break;
 
-                case SDLEventType.AppWillenterbackground:
+                case SDLEventType.WillEnterBackground:
                     break;
 
-                case SDLEventType.AppDidenterbackground:
+                case SDLEventType.DidEnterBackground:
                     break;
 
-                case SDLEventType.AppWillenterforeground:
+                case SDLEventType.WillEnterForeground:
                     break;
 
-                case SDLEventType.AppDidenterforeground:
+                case SDLEventType.DidEnterForeground:
                     break;
 
-                case SDLEventType.Localechanged:
+                case SDLEventType.LocaleChanged:
                     break;
 
-                case SDLEventType.Displayevent:
-                    break;
-
-                case SDLEventType.Windowevent:
+                case >= SDLEventType.WindowFirst and <= SDLEventType.WindowLast:
                     {
                         var even = evnt.Window;
                         if (even.WindowID == mainWindow.WindowID)
@@ -292,10 +291,8 @@
 
                     break;
 
-                case SDLEventType.Syswmevent:
-                    break;
 
-                case SDLEventType.Keydown:
+                case SDLEventType.KeyDown:
                     {
                         var even = evnt.Key;
                         Keyboard.OnKeyDown(even);
@@ -304,7 +301,7 @@
                     }
                     break;
 
-                case SDLEventType.Keyup:
+                case SDLEventType.KeyUp:
                     {
                         var even = evnt.Key;
                         Keyboard.OnKeyUp(even);
@@ -313,10 +310,10 @@
                     }
                     break;
 
-                case SDLEventType.Textediting:
+                case SDLEventType.TextEditing:
                     break;
 
-                case SDLEventType.Textinput:
+                case SDLEventType.TextInput:
                     {
                         var even = evnt.Text;
                         Keyboard.OnTextInput(even);
@@ -325,10 +322,10 @@
                     }
                     break;
 
-                case SDLEventType.Keymapchanged:
+                case SDLEventType.KeymapChanged:
                     break;
 
-                case SDLEventType.Mousemotion:
+                case SDLEventType.MouseMotion:
                     {
                         var even = evnt.Motion;
                         Mouse.OnMotion(even);
@@ -337,7 +334,7 @@
                     }
                     break;
 
-                case SDLEventType.Mousebuttondown:
+                case SDLEventType.MouseButtonDown:
                     {
                         var even = evnt.Button;
                         Mouse.OnButtonDown(even);
@@ -346,7 +343,7 @@
                     }
                     break;
 
-                case SDLEventType.Mousebuttonup:
+                case SDLEventType.MouseButtonUp:
                     {
                         var even = evnt.Button;
                         Mouse.OnButtonUp(even);
@@ -355,7 +352,7 @@
                     }
                     break;
 
-                case SDLEventType.Mousewheel:
+                case SDLEventType.MouseWheel:
                     {
                         var even = evnt.Wheel;
                         Mouse.OnWheel(even);
@@ -364,126 +361,126 @@
                     }
                     break;
 
-                case SDLEventType.Joyaxismotion:
+                case SDLEventType.JoystickAxisMotion:
                     {
                         var even = evnt.Jaxis;
                         Joysticks.OnAxisMotion(even);
                     }
                     break;
 
-                case SDLEventType.Joyballmotion:
+                case SDLEventType.JoystickBallMotion:
                     {
                         var even = evnt.Jball;
                         Joysticks.OnBallMotion(even);
                     }
                     break;
 
-                case SDLEventType.Joyhatmotion:
+                case SDLEventType.JoystickHatMotion:
                     {
                         var even = evnt.Jhat;
                         Joysticks.OnHatMotion(even);
                     }
                     break;
 
-                case SDLEventType.Joybuttondown:
+                case SDLEventType.JoystickButtonDown:
                     {
                         var even = evnt.Jbutton;
                         Joysticks.OnButtonDown(even);
                     }
                     break;
 
-                case SDLEventType.Joybuttonup:
+                case SDLEventType.JoystickButtonUp:
                     {
                         var even = evnt.Jbutton;
                         Joysticks.OnButtonUp(even);
                     }
                     break;
 
-                case SDLEventType.Joydeviceadded:
+                case SDLEventType.JoystickAdded:
                     {
                         var even = evnt.Jdevice;
                         Joysticks.AddJoystick(even);
                     }
                     break;
 
-                case SDLEventType.Joydeviceremoved:
+                case SDLEventType.JoystickRemoved:
                     {
                         var even = evnt.Jdevice;
                         Joysticks.RemoveJoystick(even);
                     }
                     break;
 
-                case SDLEventType.Controlleraxismotion:
+                case SDLEventType.GamepadAxisMotion:
                     {
-                        var even = evnt.Caxis;
+                        var even = evnt.Gaxis;
                         Gamepads.OnAxisMotion(even);
                     }
                     break;
 
-                case SDLEventType.Controllerbuttondown:
+                case SDLEventType.GamepadButtonDown:
                     {
-                        var even = evnt.Cbutton;
+                        var even = evnt.Gbutton;
                         Gamepads.OnButtonDown(even);
                     }
                     break;
 
-                case SDLEventType.Controllerbuttonup:
+                case SDLEventType.GamepadButtonUp:
                     {
-                        var even = evnt.Cbutton;
+                        var even = evnt.Gbutton;
                         Gamepads.OnButtonUp(even);
                     }
                     break;
 
-                case SDLEventType.Controllerdeviceadded:
+                case SDLEventType.GamepadAdded:
                     {
-                        var even = evnt.Cdevice;
+                        var even = evnt.Gdevice;
                         Gamepads.AddController(even);
                     }
                     break;
 
-                case SDLEventType.Controllerdeviceremoved:
+                case SDLEventType.GamepadRemoved:
                     {
-                        var even = evnt.Cdevice;
+                        var even = evnt.Gdevice;
                         Gamepads.RemoveController(even);
                     }
                     break;
 
-                case SDLEventType.Controllerdeviceremapped:
+                case SDLEventType.GamepadRemapped:
                     {
-                        var even = evnt.Cdevice;
+                        var even = evnt.Gdevice;
                         Gamepads.OnRemapped(even);
                     }
                     break;
 
-                case SDLEventType.Controllertouchpaddown:
+                case SDLEventType.GamepadTouchpadDown:
                     {
-                        var even = evnt.Ctouchpad;
+                        var even = evnt.Gtouchpad;
                         Gamepads.OnTouchPadDown(even);
                     }
                     break;
 
-                case SDLEventType.Controllertouchpadmotion:
+                case SDLEventType.GamepadTouchpadMotion:
                     {
-                        var even = evnt.Ctouchpad;
+                        var even = evnt.Gtouchpad;
                         Gamepads.OnTouchPadMotion(even);
                     }
                     break;
 
-                case SDLEventType.Controllertouchpadup:
+                case SDLEventType.GamepadTouchpadUp:
                     {
-                        var even = evnt.Ctouchpad;
+                        var even = evnt.Gtouchpad;
                         Gamepads.OnTouchPadUp(even);
                     }
                     break;
 
-                case SDLEventType.Controllersensorupdate:
+                case SDLEventType.GamepadSensorUpdate:
                     {
-                        var even = evnt.Csensor;
+                        var even = evnt.Gsensor;
                         Gamepads.OnSensorUpdate(even);
                     }
                     break;
 
-                case SDLEventType.Fingerdown:
+                case SDLEventType.FingerDown:
                     {
                         var even = evnt.Tfinger;
                         TouchDevices.FingerDown(even);
@@ -492,7 +489,7 @@
                     }
                     break;
 
-                case SDLEventType.Fingerup:
+                case SDLEventType.FingerUp:
                     {
                         var even = evnt.Tfinger;
                         TouchDevices.FingerUp(even);
@@ -501,7 +498,7 @@
                     }
                     break;
 
-                case SDLEventType.Fingermotion:
+                case SDLEventType.FingerMotion:
                     {
                         var even = evnt.Tfinger;
                         TouchDevices.FingerMotion(even);
@@ -510,43 +507,31 @@
                     }
                     break;
 
-                case SDLEventType.Dollargesture:
+              
+                case SDLEventType.ClipboardUpdate:
                     break;
 
-                case SDLEventType.Dollarrecord:
-                    break;
-
-                case SDLEventType.Multigesture:
-                    break;
-
-                case SDLEventType.Clipboardupdate:
-                    break;
-
-                case SDLEventType.Dropfile:
+                case SDLEventType.DropFile:
                     {
                         var even = evnt.Drop;
                         if (even.WindowID == mainWindow.WindowID)
                         {
                             //((SdlWindow)mainWindow).ProcessDropFile(even);
                         }
-
-                        SDL.Free(evnt.Drop.File);
                     }
                     break;
 
-                case SDLEventType.Droptext:
+                case SDLEventType.DropText:
                     {
                         var even = evnt.Drop;
                         if (even.WindowID == mainWindow.WindowID)
                         {
                             //((SdlWindow)mainWindow).ProcessDropText(even);
                         }
-
-                        SDL.Free(evnt.Drop.File);
                     }
                     break;
 
-                case SDLEventType.Dropbegin:
+                case SDLEventType.DropBegin:
                     {
                         var even = evnt.Drop;
                         if (even.WindowID == mainWindow.WindowID)
@@ -556,7 +541,7 @@
                     }
                     break;
 
-                case SDLEventType.Dropcomplete:
+                case SDLEventType.DropComplete:
                     {
                         var even = evnt.Drop;
                         if (even.WindowID == mainWindow.WindowID)
@@ -566,13 +551,13 @@
                     }
                     break;
 
-                case SDLEventType.Audiodeviceadded:
+                case SDLEventType.AudioDeviceAdded:
                     break;
 
-                case SDLEventType.Audiodeviceremoved:
+                case SDLEventType.AudioDeviceRemoved:
                     break;
 
-                case SDLEventType.Sensorupdate:
+                case SDLEventType.SensorUpdate:
                     break;
 
                 case SDLEventType.RenderTargetsReset:
@@ -581,12 +566,11 @@
                 case SDLEventType.RenderDeviceReset:
                     break;
 
-                case SDLEventType.Userevent:
-                    break;
-
-                case SDLEventType.Lastevent:
+                case SDLEventType.User:
                     break;
             }
         }
+
+       
     }
 }

--- a/Hexa.NET.KittyUI/D3D11/D3D11Adapter.cs
+++ b/Hexa.NET.KittyUI/D3D11/D3D11Adapter.cs
@@ -4,14 +4,14 @@
     using Hexa.NET.DXGI;
     using Hexa.NET.KittyUI.Windows;
     using Hexa.NET.Logging;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using HexaGen.Runtime;
     using HexaGen.Runtime.COM;
     using System.Runtime.InteropServices;
     using System.Runtime.Versioning;
     using System.Text;
     using InfoQueueFilter = Hexa.NET.DXGI.InfoQueueFilter;
-    using Window = SDL2.SDLWindow;
+    using Window = SDL3.SDLWindow;
 
     public static unsafe class D3D11Adapter
     {
@@ -184,47 +184,6 @@
 
             nint hwnd = window.GetHWND();
             IDXGIFactory.CreateSwapChainForHwnd(D3D11GraphicsDevice.Device.As<IUnknown>(), hwnd, &desc, &fullscreenDesc, IDXGIOutput.As<IDXGIOutput>(), out ComPtr<IDXGISwapChain1> swapChain);
-
-            return new DXGISwapChain(swapChain, (SwapChainFlag)desc.Flags);
-        }
-
-        [SupportedOSPlatform("windows")]
-        internal static DXGISwapChain CreateSwapChainForWindow(Window* window)
-        {
-            SDLSysWMInfo info;
-            SDL.GetVersion(&info.Version);
-            SDL.GetWindowWMInfo(window, &info);
-
-            int width = 0;
-            int height = 0;
-
-            SDL.GetWindowSize(window, &width, &height);
-
-            var Hwnd = info.Info.Win.Window;
-
-            SwapChainDesc1 desc = new()
-            {
-                Width = (uint)width,
-                Height = (uint)height,
-                Format = AutoChooseSwapChainFormat(D3D11GraphicsDevice.Device, IDXGIOutput),
-                BufferCount = 2,
-                BufferUsage = (uint)DXGI.DXGI_USAGE_RENDER_TARGET_OUTPUT,
-                SampleDesc = new(1, 0),
-                Scaling = Scaling.Stretch,
-                SwapEffect = SwapEffect.FlipSequential,
-                Flags = (uint)(SwapChainFlag.AllowModeSwitch | SwapChainFlag.AllowTearing | SwapChainFlags)
-            };
-
-            SwapChainFullscreenDesc fullscreenDesc = new()
-            {
-                Windowed = 1,
-                RefreshRate = new Rational(0, 1),
-                Scaling = ModeScaling.Unspecified,
-                ScanlineOrdering = ModeScanlineOrder.Unspecified,
-            };
-
-            ComPtr<IDXGISwapChain1> swapChain = default;
-            IDXGIFactory.CreateSwapChainForHwnd(D3D11GraphicsDevice.Device.As<IUnknown>(), Hwnd, &desc, &fullscreenDesc, IDXGIOutput.As<IDXGIOutput>(), out swapChain);
 
             return new DXGISwapChain(swapChain, (SwapChainFlag)desc.Flags);
         }

--- a/Hexa.NET.KittyUI/Debugging/Console.cs
+++ b/Hexa.NET.KittyUI/Debugging/Console.cs
@@ -369,7 +369,7 @@
                 footerHeightToReserve += ImGui.GetStyle().ItemSpacing.Y;
             }
 
-            if (ImGui.BeginChild("ScrollRegion##", new Vector2(0, -footerHeightToReserve), 0, 0))
+            if (ImGui.BeginChild("ScrollRegion##"u8, new Vector2(0, -footerHeightToReserve)))
             {
                 float scrollPos = ImGui.GetScrollY();
                 float lineHeight = ImGui.GetTextLineHeightWithSpacing();

--- a/Hexa.NET.KittyUI/EventHook.cs
+++ b/Hexa.NET.KittyUI/EventHook.cs
@@ -1,6 +1,6 @@
 namespace Hexa.NET.KittyUI
 {
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
 
     public delegate bool EventHook(SDLEvent evnt);
 }

--- a/Hexa.NET.KittyUI/Extensions/SdlErrorHandlingExtensions.cs
+++ b/Hexa.NET.KittyUI/Extensions/SdlErrorHandlingExtensions.cs
@@ -1,7 +1,7 @@
 ﻿namespace Hexa.NET.KittyUI.Extensions
 {
     using Hexa.NET.Logging;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using HexaGen.Runtime;
     using System.Runtime.CompilerServices;
 
@@ -121,6 +121,16 @@
             return ptr;
 #else
             return ptr;
+#endif
+        }
+
+        public static void SdlThrowIfFalse(this bool result)
+        {
+#if DEBUG
+            if (!result)
+            {
+                Logger.ThrowIfNotNull(SDL.GetErrorAsException());
+            }
 #endif
         }
     }

--- a/Hexa.NET.KittyUI/Hexa.NET.KittyUI.csproj
+++ b/Hexa.NET.KittyUI/Hexa.NET.KittyUI.csproj
@@ -53,7 +53,7 @@
 	  <EmbeddedResource Include="assets\fonts\MaterialSymbolsRounded.ttf" />
 	</ItemGroup>
 
-	<ItemGroup>
+	<ItemGroup>	
 		<PackageReference Include="Hexa.NET.ImGui.Widgets" Version="1.2.13" />
 		<PackageReference Include="Hexa.NET.ImGui.Widgets.Extras" Version="1.0.6" />
 		<PackageReference Include="Hexa.NET.ImGui" Version="2.2.7" />
@@ -61,7 +61,7 @@
 		<PackageReference Include="Hexa.NET.ImNodes" Version="2.2.7" />
 		<PackageReference Include="Hexa.NET.ImPlot" Version="2.2.7" />
 		<PackageReference Include="Hexa.NET.ImGui.Backends" Version="1.0.15" />
-		<PackageReference Include="Hexa.NET.ImGui.Backends.SDL2" Version="1.0.15" />
+		<PackageReference Include="Hexa.NET.ImGui.Backends.SDL3" Version="1.0.15" />
 		<PackageReference Include="Hexa.NET.Logging" Version="2.0.0" />
 		<PackageReference Include="Hexa.NET.Math" Version="2.0.6" />
 		<PackageReference Include="Hexa.NET.Utilities" Version="2.2.2" />
@@ -74,7 +74,7 @@
 		<PackageReference Include="Hexa.NET.OpenGLES3" Version="1.1.0" />
 		<PackageReference Include="Hexa.NET.OpenGLES.EXT" Version="1.1.0" />
 		<PackageReference Include="Hexa.NET.OpenGLES.KHR" Version="1.1.0" />
-		<PackageReference Include="Hexa.NET.SDL2" Version="1.2.14" />
+		<PackageReference Include="Hexa.NET.SDL3" Version="1.2.16" />
 		<PackageReference Include="Hexa.NET.D3DCompiler" Version="1.0.6" />
 		<PackageReference Include="Hexa.NET.D3D11" Version="1.0.6" />
 		<PackageReference Include="Hexa.NET.DXGI" Version="1.0.6" />

--- a/Hexa.NET.KittyUI/ImGuiBackend/ImGuiManager.cs
+++ b/Hexa.NET.KittyUI/ImGuiBackend/ImGuiManager.cs
@@ -1,7 +1,7 @@
 ﻿namespace Hexa.NET.KittyUI.ImGuiBackend
 {
     using Hexa.NET.ImGui;
-    using Hexa.NET.ImGui.Backends.SDL2;
+    using Hexa.NET.ImGui.Backends.SDL3;
     using Hexa.NET.KittyUI;
     using System.Diagnostics;
     using System.Numerics;
@@ -186,7 +186,7 @@
             }
 
             RendererNewFrameCallback();
-            ImGuiImplSDL2.NewFrame();
+            ImGuiImplSDL3.SDL3NewFrame();
             ImGui.NewFrame();
 
             foreach (var addon in addons)
@@ -231,6 +231,11 @@
                     addon.Dispose();
                 }
 
+                var io = ImGui.GetIO();
+                if ((io.ConfigFlags & ImGuiConfigFlags.ViewportsEnable) != 0)
+                {
+                    ImGui.DestroyPlatformWindows();
+                }
                 ImGui.DestroyContext(guiContext);
                 ImGui.SetCurrentContext(null);
                 disposedValue = true;

--- a/Hexa.NET.KittyUI/Input/Events/KeyboardCharEventArgs.cs
+++ b/Hexa.NET.KittyUI/Input/Events/KeyboardCharEventArgs.cs
@@ -5,27 +5,18 @@
     /// <summary>
     /// Provides data for keyboard character input events.
     /// </summary>
-    public class KeyboardCharEventArgs : RoutedEventArgs
+    public class TextInputEventArgs : RoutedEventArgs
     {
         /// <summary>
-        /// Initializes a new instance of the <see cref="KeyboardCharEventArgs"/> class.
+        /// Initializes a new instance of the <see cref="TextInputEventArgs"/> class.
         /// </summary>
-        public KeyboardCharEventArgs()
+        public TextInputEventArgs()
         {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see cref="KeyboardCharEventArgs"/> class.
-        /// </summary>
-        /// <param name="char">The character.</param>
-        public KeyboardCharEventArgs(char @char)
-        {
-            Char = @char;
         }
 
         /// <summary>
         /// Gets the character associated with the event.
         /// </summary>
-        public char Char { get; internal set; }
+        public unsafe byte* Text { get; internal set; }
     }
 }

--- a/Hexa.NET.KittyUI/Input/Events/MouseButtonEventArgs.cs
+++ b/Hexa.NET.KittyUI/Input/Events/MouseButtonEventArgs.cs
@@ -1,5 +1,7 @@
 ﻿namespace Hexa.NET.KittyUI.Input.Events
 {
+    using System.Numerics;
+
     /// <summary>
     /// Provides data for mouse button input events.
     /// </summary>
@@ -39,5 +41,10 @@
         /// Gets the number of clicks associated with the event.
         /// </summary>
         public int Clicks { get; internal set; }
+
+        /// <summary>
+        /// Gets the mouse position on the window.
+        /// </summary>
+        public Vector2 Position { get; set; }
     }
 }

--- a/Hexa.NET.KittyUI/Input/Finger.cs
+++ b/Hexa.NET.KittyUI/Input/Finger.cs
@@ -7,7 +7,7 @@
     /// </summary>
     public unsafe class Finger
     {
-        private readonly SDL2.SDLFinger* finger;
+        private readonly SDL3.SDLFinger* finger;
         private readonly long id;
         private FingerState state;
 
@@ -15,7 +15,7 @@
         /// Initializes a new instance of the <see cref="Finger"/> class.
         /// </summary>
         /// <param name="finger">A pointer to the native SDL finger.</param>
-        public Finger(SDL2.SDLFinger* finger)
+        public Finger(SDL3.SDLFinger* finger)
         {
             this.finger = finger;
             id = finger->Id;

--- a/Hexa.NET.KittyUI/Input/Gamepad.cs
+++ b/Hexa.NET.KittyUI/Input/Gamepad.cs
@@ -1,10 +1,9 @@
 ﻿namespace Hexa.NET.KittyUI.Input
 {
     using Hexa.NET.KittyUI.Input.Events;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using System.Numerics;
     using System.Runtime.CompilerServices;
-    using System.Text;
     using static Extensions.SdlErrorHandlingExtensions;
 
     /// <summary>
@@ -20,7 +19,7 @@
         private static readonly GamepadSensorType[] sensorTypes = Enum.GetValues<GamepadSensorType>();
 
         private readonly int id;
-        private readonly SDLGameController* controller;
+        private readonly SDLGamepad* controller;
         internal readonly SDLJoystick* joystick;
         private readonly Dictionary<GamepadAxis, short> axisStates = new();
         private readonly Dictionary<GamepadButton, GamepadButtonState> buttonStates = new();
@@ -40,11 +39,11 @@
         {
             for (int i = 0; i < axes.Length; i++)
             {
-                axisNames[i] = SDL.GameControllerGetStringForAxisS(Helper.ConvertBack(axes[i]));
+                axisNames[i] = SDL.GetGamepadStringForAxisS(Helper.ConvertBack(axes[i]));
             }
             for (int i = 0; i < buttons.Length; i++)
             {
-                buttonNames[i] = SDL.GameControllerGetStringForButtonS(Helper.ConvertBack(buttons[i]));
+                buttonNames[i] = SDL.GetGamepadStringForButtonS(Helper.ConvertBack(buttons[i]));
             }
         }
 
@@ -54,17 +53,23 @@
         /// <param name="id">The unique identifier for the gamepad.</param>
         public Gamepad(int id)
         {
-            controller = SDL.GameControllerOpen(id);
+            controller = SDL.OpenGamepad(id);
             if (controller == null)
+            {
                 SdlCheckError();
-            joystick = SDL.GameControllerGetJoystick(controller);
+            }
+
+            joystick = SDL.GetGamepadJoystick(controller);
             if (controller == null)
+            {
                 SdlCheckError();
-            this.id = SDL.JoystickInstanceID(joystick).SdlThrowIfNeg();
+            }
+
+            this.id = SDL.GetJoystickID(joystick).SdlThrowIfNeg();
             var axes = Enum.GetValues<GamepadAxis>();
             for (int i = 0; i < axes.Length; i++)
             {
-                if (SDL.GameControllerHasAxis(controller, Helper.ConvertBack(axes[i])) == SDLBool.True)
+                if (SDL.GamepadHasAxis(controller, Helper.ConvertBack(axes[i])))
                 {
                     axisStates.Add(axes[i], 0);
                 }
@@ -72,13 +77,13 @@
             var buttons = Enum.GetValues<GamepadButton>();
             for (int i = 0; i < buttons.Length; i++)
             {
-                if (SDL.GameControllerHasButton(controller, Helper.ConvertBack(buttons[i])) == SDLBool.True)
+                if (SDL.GamepadHasButton(controller, Helper.ConvertBack(buttons[i])))
                 {
                     buttonStates.Add(buttons[i], GamepadButtonState.Up);
                 }
             }
 
-            var touchpadCount = SDL.GameControllerGetNumTouchpads(controller);
+            var touchpadCount = SDL.GetNumGamepadTouchpads(controller);
             for (int i = 0; i < touchpadCount; i++)
             {
                 touchpads.Add(new(i, controller));
@@ -87,35 +92,36 @@
             var sensorTypes = Enum.GetValues<GamepadSensorType>();
             for (int i = 0; i < sensorTypes.Length; i++)
             {
-                if (SDL.GameControllerHasSensor(controller, Helper.ConvertBack(sensorTypes[i])) == SDLBool.True)
+                if (SDL.GamepadHasSensor(controller, Helper.ConvertBack(sensorTypes[i])))
                 {
                     sensors.Add(sensorTypes[i], new(controller, sensorTypes[i]));
                 }
             }
 
-            var mappingCount = SDL.GameControllerNumMappings();
+            int mappingCount;
+            var outMappings = SDL.GetGamepadMappings(&mappingCount);
             for (int i = 0; i < mappingCount; i++)
             {
-                var mapping = SDL.GameControllerMappingForIndexS(i);
+                var mapping = ToStringFromUTF8(outMappings[i]);
                 if (mapping == null)
+                {
                     SdlCheckError();
+                }
+
                 mappings.Add(mapping ?? string.Empty);
             }
 
-            if (SDL.JoystickIsHaptic(joystick) == 1)
+            if (SDL.IsJoystickHaptic(joystick))
             {
                 haptic = Haptic.OpenFromGamepad(this);
             }
 
-            var guid = SDL.JoystickGetGUID(joystick);
+            SdlGuid guid = SDL.GetJoystickGUID(joystick);
             SdlCheckError();
-            var buffer = AllocT<byte>(33);
-            SDL.JoystickGetGUIDString(guid, buffer, 33);
-            var size = StrLen(buffer);
-            var value = Encoding.ASCII.GetString(buffer, size - 1);
-            Free(buffer);
-            this.guid = value;
+            this.guid = (*(Guid*)&guid).ToString();
         }
+
+        protected uint Props => SDL.GetGamepadProperties(controller);
 
         /// <summary>
         /// Gets the list of available gamepad axes.
@@ -154,9 +160,12 @@
         {
             get
             {
-                var name = SDL.GameControllerNameS(controller);
+                var name = SDL.GetGamepadNameS(controller);
                 if (name == null)
+                {
                     SdlCheckError();
+                }
+
                 return name ?? string.Empty;
             }
         }
@@ -164,22 +173,22 @@
         /// <summary>
         /// Gets the vendor ID of the gamepad.
         /// </summary>
-        public ushort Vendor => SDL.GameControllerGetVendor(controller);
+        public ushort Vendor => SDL.GetGamepadVendor(controller);
 
         /// <summary>
         /// Gets the product ID of the gamepad.
         /// </summary>
-        public ushort Product => SDL.GameControllerGetProduct(controller);
+        public ushort Product => SDL.GetGamepadProduct(controller);
 
         /// <summary>
         /// Gets the product version of the gamepad.
         /// </summary>
-        public ushort ProductVersion => SDL.GameControllerGetProductVersion(controller);
+        public ushort ProductVersion => SDL.GetGamepadProductVersion(controller);
 
         /// <summary>
         /// Gets the serial number of the gamepad.
         /// </summary>
-        public string Serial => SDL.GameControllerGetSerialS(controller);
+        public string Serial => SDL.GetGamepadSerialS(controller);
 
         /// <summary>
         /// Gets the globally unique identifier (GUID) of the gamepad.
@@ -189,22 +198,32 @@
         /// <summary>
         /// Gets a value indicating whether the gamepad is currently attached.
         /// </summary>
-        public bool IsAttached => SDL.GameControllerGetAttached(controller) == SDLBool.True;
+        public bool IsAttached => SDL.GamepadConnected(controller);
 
         /// <summary>
         /// Gets a value indicating whether the gamepad has haptic feedback support.
         /// </summary>
-        public bool IsHaptic => SDL.JoystickIsHaptic(joystick) == 1;
+        public bool IsHaptic => SDL.IsJoystickHaptic(joystick);
 
         /// <summary>
         /// Gets a value indicating whether the gamepad has LED support.
         /// </summary>
-        public bool HasLED => SDL.GameControllerHasLED(controller) == SDLBool.True;
+        public bool HasLED => SDL.HasProperty(Props, SDL.SDL_PROP_GAMEPAD_CAP_RGB_LED_BOOLEAN);
+
+        /// <summary>
+        /// Gets a value indicating whether the gamepad has rumble support.
+        /// </summary>
+        public bool HasRumble => SDL.HasProperty(Props, SDL.SDL_PROP_GAMEPAD_CAP_RUMBLE_BOOLEAN);
+
+        /// <summary>
+        /// Gets a value indicating whether the gamepad has trigger rumble support.
+        /// </summary>
+        public bool HasTriggerRumble => SDL.HasProperty(Props, SDL.SDL_PROP_GAMEPAD_CAP_TRIGGER_RUMBLE_BOOLEAN);
 
         /// <summary>
         /// Gets the type of the gamepad.
         /// </summary>
-        public GamepadType Type => Helper.Convert(SDL.GameControllerGetType(controller));
+        public GamepadType Type => Helper.Convert(SDL.GetGamepadType(controller));
 
         /// <summary>
         /// Gets or sets the deadzone value for gamepad analog sticks.
@@ -214,7 +233,7 @@
         /// <summary>
         /// Gets or sets the player index for the gamepad.
         /// </summary>
-        public int PlayerIndex { get => SDL.GameControllerGetPlayerIndex(controller); set => SDL.GameControllerSetPlayerIndex(controller, value); }
+        public int PlayerIndex { get => SDL.GetGamepadPlayerIndex(controller); set => SDL.SetGamepadPlayerIndex(controller, value); }
 
         /// <summary>
         /// Gets the controller mapping string of the gamepad.
@@ -223,9 +242,12 @@
         {
             get
             {
-                var mapping = SDL.GameControllerMappingS(controller);
+                var mapping = SDL.GetGamepadMappingS(controller);
                 if (mapping == null)
+                {
                     SdlCheckError();
+                }
+
                 return mapping ?? string.Empty;
             }
         }
@@ -338,7 +360,7 @@
         /// <param name="durationMs">The duration in milliseconds for the rumble.</param>
         public void Rumble(ushort lowFreq, ushort highFreq, uint durationMs)
         {
-            SDL.GameControllerRumble(controller, lowFreq, highFreq, durationMs);
+            SDL.RumbleGamepad(controller, lowFreq, highFreq, durationMs);
         }
 
         /// <summary>
@@ -349,7 +371,7 @@
         /// <param name="durationMs">The duration in milliseconds for the rumble.</param>
         public void RumbleTriggers(ushort rightRumble, ushort leftRumble, uint durationMs)
         {
-            SDL.GameControllerRumbleTriggers(controller, rightRumble, leftRumble, durationMs);
+            SDL.RumbleGamepadTriggers(controller, rightRumble, leftRumble, durationMs);
         }
 
         /// <summary>
@@ -358,7 +380,7 @@
         /// <param name="color">The color represented as a Vector4 (red, green, blue, alpha).</param>
         public void SetLED(Vector4 color)
         {
-            SDL.GameControllerSetLED(controller, (byte)(color.X * 255), (byte)(color.Y * 255), (byte)(color.Z * 255));
+            SDL.SetGamepadLED(controller, (byte)(color.X * 255), (byte)(color.Y * 255), (byte)(color.Z * 255));
         }
 
         /// <summary>
@@ -369,7 +391,7 @@
         /// <param name="blue">The blue color component (0-255).</param>
         public void SetLED(byte red, byte green, byte blue)
         {
-            SDL.GameControllerSetLED(controller, red, green, blue);
+            SDL.SetGamepadLED(controller, red, green, blue);
         }
 
         /// <summary>
@@ -378,7 +400,7 @@
         /// <param name="mapping">The custom gamepad mapping string to add.</param>
         public void AddMapping(string mapping)
         {
-            SDL.GameControllerAddMapping(mapping).SdlThrowIfNeg();
+            SDL.AddGamepadMapping(mapping).SdlThrowIfNeg();
             mappings.Add(mapping);
         }
 
@@ -392,9 +414,9 @@
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal (Gamepad Gamepad, GamepadAxisMotionEventArgs EventArgs)? OnAxisMotion(SDLControllerAxisEvent even)
+        internal (Gamepad Gamepad, GamepadAxisMotionEventArgs EventArgs)? OnAxisMotion(SDLGamepadAxisEvent even)
         {
-            var axis = Helper.Convert((SDLGameControllerAxis)even.Axis);
+            var axis = Helper.Convert((SDLGamepadAxis)even.Axis);
             if (Math.Abs((int)even.Value) < deadzone)
             {
                 even.Value = 0;
@@ -416,9 +438,9 @@
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal (Gamepad Gamepad, GamepadButtonEventArgs EventArgs) OnButtonDown(SDLControllerButtonEvent even)
+        internal (Gamepad Gamepad, GamepadButtonEventArgs EventArgs) OnButtonDown(SDLGamepadButtonEvent even)
         {
-            var button = Helper.Convert((SDLGameControllerButton)even.Button);
+            var button = Helper.Convert((SDLGamepadButton)even.Button);
             buttonStates[button] = GamepadButtonState.Down;
             buttonEventArgs.Timestamp = even.Timestamp;
             buttonEventArgs.Handled = false;
@@ -430,9 +452,9 @@
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal (Gamepad Gamepad, GamepadButtonEventArgs EventArgs) OnButtonUp(SDLControllerButtonEvent even)
+        internal (Gamepad Gamepad, GamepadButtonEventArgs EventArgs) OnButtonUp(SDLGamepadButtonEvent even)
         {
-            var button = Helper.Convert((SDLGameControllerButton)even.Button);
+            var button = Helper.Convert((SDLGamepadButton)even.Button);
             buttonStates[button] = GamepadButtonState.Up;
             buttonEventArgs.Timestamp = even.Timestamp;
             buttonEventArgs.Handled = false;
@@ -444,25 +466,25 @@
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal (GamepadTouchpad Touchpad, GamepadTouchpadEventArgs EventArgs) OnTouchPadDown(SDLControllerTouchpadEvent even)
+        internal (GamepadTouchpad Touchpad, GamepadTouchpadEventArgs EventArgs) OnTouchPadDown(SDLGamepadTouchpadEvent even)
         {
             return touchpads[even.Touchpad].OnTouchPadDown(even);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal (GamepadTouchpad Touchpad, GamepadTouchpadMotionEventArgs EventArgs) OnTouchPadMotion(SDLControllerTouchpadEvent even)
+        internal (GamepadTouchpad Touchpad, GamepadTouchpadMotionEventArgs EventArgs) OnTouchPadMotion(SDLGamepadTouchpadEvent even)
         {
             return touchpads[even.Touchpad].OnTouchPadMotion(even);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal (GamepadTouchpad Touchpad, GamepadTouchpadEventArgs EventArgs) OnTouchPadUp(SDLControllerTouchpadEvent even)
+        internal (GamepadTouchpad Touchpad, GamepadTouchpadEventArgs EventArgs) OnTouchPadUp(SDLGamepadTouchpadEvent even)
         {
             return touchpads[even.Touchpad].OnTouchPadUp(even);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal (GamepadSensor Sensor, GamepadSensorUpdateEventArgs EventArgs) OnSensorUpdate(SDLControllerSensorEvent even)
+        internal (GamepadSensor Sensor, GamepadSensorUpdateEventArgs EventArgs) OnSensorUpdate(SDLGamepadSensorEvent even)
         {
             return sensors[Helper.Convert((SDLSensorType)even.Sensor)].OnSensorUpdate(even);
         }
@@ -475,7 +497,7 @@
             {
                 sensor.Value?.Dispose();
             }
-            SDL.GameControllerClose(controller);
+            SDL.CloseGamepad(controller);
             SdlCheckError();
         }
     }

--- a/Hexa.NET.KittyUI/Input/GamepadSensor.cs
+++ b/Hexa.NET.KittyUI/Input/GamepadSensor.cs
@@ -1,9 +1,8 @@
 ﻿namespace Hexa.NET.KittyUI.Input
 {
     using Hexa.NET.KittyUI.Input.Events;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using System.Numerics;
-    using static Extensions.SdlErrorHandlingExtensions;
 
     /// <summary>
     /// Represents a generic delegate for handling gamepad sensor events.
@@ -18,7 +17,7 @@
     /// </summary>
     public unsafe class GamepadSensor : IDisposable
     {
-        private readonly SDLGameController* controller;
+        private readonly SDLGamepad* controller;
         private readonly GamepadSensorType type;
         private readonly float* buffer;
         private readonly int length = 3;
@@ -32,12 +31,12 @@
         /// </summary>
         /// <param name="controller">The game controller associated with the sensor.</param>
         /// <param name="sensorType">The type of sensor.</param>
-        public GamepadSensor(SDLGameController* controller, GamepadSensorType sensorType)
+        public GamepadSensor(SDLGamepad* controller, GamepadSensorType sensorType)
         {
             this.controller = controller;
             type = sensorType;
             buffer = AllocT<float>(3);
-            SDL.GameControllerGetSensorData(controller, Helper.ConvertBack(sensorType), buffer, length).SdlThrowIfNeg();
+            SDL.GetGamepadSensorData(controller, Helper.ConvertBack(sensorType), buffer, length);
         }
 
         /// <summary>
@@ -45,8 +44,8 @@
         /// </summary>
         public bool Enabled
         {
-            get => SDL.GameControllerIsSensorEnabled(controller, Helper.ConvertBack(type)) == SDLBool.True;
-            set => SDL.GameControllerSetSensorEnabled(controller, Helper.ConvertBack(type), value ? SDLBool.True : SDLBool.False).SdlThrowIfNeg();
+            get => SDL.GamepadSensorEnabled(controller, Helper.ConvertBack(type));
+            set => SDL.SetGamepadSensorEnabled(controller, Helper.ConvertBack(type), value);
         }
 
         /// <summary>
@@ -69,7 +68,7 @@
         /// </summary>
         public event GamepadSensorEventHandler<GamepadSensorUpdateEventArgs>? SensorUpdate;
 
-        internal (GamepadSensor Sensor, GamepadSensorUpdateEventArgs EventArgs) OnSensorUpdate(SDLControllerSensorEvent even)
+        internal (GamepadSensor Sensor, GamepadSensorUpdateEventArgs EventArgs) OnSensorUpdate(SDLGamepadSensorEvent even)
         {
             MemcpyT(&even.Data_0, buffer, length);
             sensorUpdateEventArgs.Timestamp = even.Timestamp;
@@ -87,7 +86,7 @@
         /// </summary>
         public void Flush()
         {
-            SDL.GameControllerGetSensorData(controller, Helper.ConvertBack(type), buffer, length).SdlThrowIfNeg();
+            SDL.GetGamepadSensorData(controller, Helper.ConvertBack(type), buffer, length);
             sensorUpdateEventArgs.Data = buffer;
             sensorUpdateEventArgs.Length = length;
             sensorUpdateEventArgs.Type = type;
@@ -105,15 +104,6 @@
                 Free(buffer);
                 disposedValue = true;
             }
-        }
-
-        /// <summary>
-        /// Finalizes an instance of the <see cref="GamepadSensor"/> class.
-        /// </summary>
-        ~GamepadSensor()
-        {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: false);
         }
 
         /// <summary>

--- a/Hexa.NET.KittyUI/Input/GamepadTouchpad.cs
+++ b/Hexa.NET.KittyUI/Input/GamepadTouchpad.cs
@@ -1,7 +1,7 @@
 ﻿namespace Hexa.NET.KittyUI.Input
 {
     using Hexa.NET.KittyUI.Input.Events;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
 
     /// <summary>
     /// Represents a delegate for handling events related to a gamepad touchpad.
@@ -17,7 +17,7 @@
     public unsafe class GamepadTouchpad
     {
         private readonly int id;
-        private readonly SDLGameController* controller;
+        private readonly SDLGamepad* controller;
         private readonly GamepadTouchpadFinger[] fingerStates;
 
         private readonly GamepadTouchpadEventArgs touchpadEventArgs = new();
@@ -28,20 +28,20 @@
         /// </summary>
         /// <param name="id">The ID of the touchpad.</param>
         /// <param name="controller">The game controller associated with the touchpad.</param>
-        public GamepadTouchpad(int id, SDLGameController* controller)
+        public GamepadTouchpad(int id, SDLGamepad* controller)
         {
             this.id = id;
             this.controller = controller;
-            var fingerCount = SDL.GameControllerGetNumTouchpadFingers(controller, id);
+            var fingerCount = SDL.GetNumGamepadTouchpadFingers(controller, id);
             fingerStates = new GamepadTouchpadFinger[fingerCount];
             for (int i = 0; i < fingerCount; i++)
             {
-                byte state;
+                bool state;
                 float x;
                 float y;
                 float pressure;
-                SDL.GameControllerGetTouchpadFinger(controller, id, i, &state, &x, &y, &pressure);
-                fingerStates[i] = new(state == SDL.SDL_PRESSED ? FingerState.Down : FingerState.Up, x, y, pressure);
+                SDL.GetGamepadTouchpadFinger(controller, id, i, &state, &x, &y, &pressure);
+                fingerStates[i] = new(state ? FingerState.Down : FingerState.Up, x, y, pressure);
             }
         }
 
@@ -70,7 +70,7 @@
         /// </summary>
         public event GamepadTouchpadEventHandler<GamepadTouchpadEventArgs>? TouchPadUp;
 
-        internal (GamepadTouchpad Touchpad, GamepadTouchpadEventArgs EventArgs) OnTouchPadDown(SDLControllerTouchpadEvent even)
+        internal (GamepadTouchpad Touchpad, GamepadTouchpadEventArgs EventArgs) OnTouchPadDown(SDLGamepadTouchpadEvent even)
         {
             var state = fingerStates[even.Finger];
             state.State = FingerState.Down;
@@ -92,7 +92,7 @@
             return (this, touchpadEventArgs);
         }
 
-        internal (GamepadTouchpad Touchpad, GamepadTouchpadMotionEventArgs EventArgs) OnTouchPadMotion(SDLControllerTouchpadEvent even)
+        internal (GamepadTouchpad Touchpad, GamepadTouchpadMotionEventArgs EventArgs) OnTouchPadMotion(SDLGamepadTouchpadEvent even)
         {
             var state = fingerStates[even.Finger];
             state.X = even.X;
@@ -112,7 +112,7 @@
             return (this, motionEventArgs);
         }
 
-        internal (GamepadTouchpad Touchpad, GamepadTouchpadEventArgs EventArgs) OnTouchPadUp(SDLControllerTouchpadEvent even)
+        internal (GamepadTouchpad Touchpad, GamepadTouchpadEventArgs EventArgs) OnTouchPadUp(SDLGamepadTouchpadEvent even)
         {
             var state = fingerStates[even.Finger];
             state.State = FingerState.Up;
@@ -171,12 +171,12 @@
         {
             for (int i = 0; i < fingerStates.Length; i++)
             {
-                byte state;
+                bool state;
                 float x;
                 float y;
                 float pressure;
-                SDL.GameControllerGetTouchpadFinger(controller, id, i, &state, &x, &y, &pressure);
-                fingerStates[i] = new(state == SDL.SDL_PRESSED ? FingerState.Down : FingerState.Up, x, y, pressure);
+                SDL.GetGamepadTouchpadFinger(controller, id, i, &state, &x, &y, &pressure);
+                fingerStates[i] = new(state ? FingerState.Down : FingerState.Up, x, y, pressure);
             }
         }
     }

--- a/Hexa.NET.KittyUI/Input/Gamepads.cs
+++ b/Hexa.NET.KittyUI/Input/Gamepads.cs
@@ -1,7 +1,7 @@
 ﻿namespace Hexa.NET.KittyUI.Input
 {
     using Hexa.NET.KittyUI.Input.Events;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using System.Runtime.CompilerServices;
 
     /// <summary>
@@ -93,7 +93,7 @@
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void AddController(SDLControllerDeviceEvent even)
+        internal static void AddController(SDLGamepadDeviceEvent even)
         {
             Gamepad gamepad = new(even.Which);
             gamepads.Add(gamepad);
@@ -104,7 +104,7 @@
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void RemoveController(SDLControllerDeviceEvent even)
+        internal static void RemoveController(SDLGamepadDeviceEvent even)
         {
             Gamepad gamepad = idToGamepads[even.Which];
             gamepadEventArgs.Timestamp = even.Timestamp;
@@ -117,14 +117,14 @@
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void OnRemapped(SDLControllerDeviceEvent even)
+        internal static void OnRemapped(SDLGamepadDeviceEvent even)
         {
             var result = idToGamepads[even.Which].OnRemapped();
             Remapped?.Invoke(result.Gamepad, result.EventArgs);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void OnAxisMotion(SDLControllerAxisEvent even)
+        internal static void OnAxisMotion(SDLGamepadAxisEvent even)
         {
             var result = idToGamepads[even.Which].OnAxisMotion(even);
             if (result == null)
@@ -134,42 +134,42 @@
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void OnButtonDown(SDLControllerButtonEvent even)
+        internal static void OnButtonDown(SDLGamepadButtonEvent even)
         {
             var result = idToGamepads[even.Which].OnButtonDown(even);
             ButtonDown?.Invoke(result.Gamepad, result.EventArgs);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void OnButtonUp(SDLControllerButtonEvent even)
+        internal static void OnButtonUp(SDLGamepadButtonEvent even)
         {
             var result = idToGamepads[even.Which].OnButtonUp(even);
             ButtonUp?.Invoke(result.Gamepad, result.EventArgs);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void OnTouchPadDown(SDLControllerTouchpadEvent even)
+        internal static void OnTouchPadDown(SDLGamepadTouchpadEvent even)
         {
             var result = idToGamepads[even.Which].OnTouchPadDown(even);
             TouchPadDown?.Invoke(result.Touchpad, result.EventArgs);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void OnTouchPadMotion(SDLControllerTouchpadEvent even)
+        internal static void OnTouchPadMotion(SDLGamepadTouchpadEvent even)
         {
             var result = idToGamepads[even.Which].OnTouchPadMotion(even);
             TouchPadMotion?.Invoke(result.Touchpad, result.EventArgs);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void OnTouchPadUp(SDLControllerTouchpadEvent even)
+        internal static void OnTouchPadUp(SDLGamepadTouchpadEvent even)
         {
             var result = idToGamepads[even.Which].OnTouchPadUp(even);
             TouchPadUp?.Invoke(result.Touchpad, result.EventArgs);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void OnSensorUpdate(SDLControllerSensorEvent even)
+        internal static void OnSensorUpdate(SDLGamepadSensorEvent even)
         {
             var result = idToGamepads[even.Which].OnSensorUpdate(even);
             SensorUpdate?.Invoke(result.Sensor, result.EventArgs);

--- a/Hexa.NET.KittyUI/Input/Haptic.cs
+++ b/Hexa.NET.KittyUI/Input/Haptic.cs
@@ -1,56 +1,55 @@
 ﻿namespace Hexa.NET.KittyUI.Input
 {
-    using Hexa.NET.SDL2;
-    using static Extensions.SdlErrorHandlingExtensions;
+    using Hexa.NET.SDL3;
 
     /// <summary>
     /// Represents a haptic feedback device that can provide force feedback sensations.
     /// </summary>
     public unsafe class Haptic
     {
-        private readonly int id;
+        private readonly uint id;
         private readonly SDLHaptic* haptic;
 
         private Haptic(SDLHaptic* haptic)
         {
             this.haptic = haptic;
-            id = SDL.HapticIndex(haptic).SdlThrowIfNeg();
+            id = SDL.GetHapticID(haptic);
         }
 
         /// <summary>
         /// Gets the unique identifier of the haptic feedback device.
         /// </summary>
-        public int Id => id;
+        public uint Id => id;
 
         /// <summary>
         /// Gets the name of the haptic feedback device.
         /// </summary>
-        public string Name => SDL.HapticNameS(id);
+        public string Name => SDL.GetHapticNameS(haptic);
 
         /// <summary>
         /// Gets the number of axes (directions) supported by the haptic feedback device.
         /// </summary>
-        public int AxesCount => SDL.HapticNumAxes(haptic);
+        public int AxesCount => SDL.GetNumHapticAxes(haptic);
 
         /// <summary>
         /// Gets the number of effects (force feedback patterns) that can be stored and played by the haptic feedback device.
         /// </summary>
-        public int EffectsCount => SDL.HapticNumEffects(haptic);
+        public int EffectsCount => SDL.GetMaxHapticEffects(haptic);
 
         /// <summary>
-        /// Gets the number of effects currently playing on the haptic feedback device.
+        /// Gets the number of effects max playing on the haptic feedback device.
         /// </summary>
-        public int EffectsPlayingCount => SDL.HapticNumEffectsPlaying(haptic);
+        public int EffectsPlayingCount => SDL.GetMaxHapticEffectsPlaying(haptic);
 
         /// <summary>
         /// Gets a value indicating whether the haptic feedback device supports rumble (vibration) effects.
         /// </summary>
-        public bool RumbleSupported => SDL.HapticRumbleSupported(haptic) == 1;
+        public bool RumbleSupported => SDL.HapticRumbleSupported(haptic);
 
         /// <summary>
         /// Gets a set of flags that specify the types of haptic effects supported by the device.
         /// </summary>
-        public HapticEffectFlags EffectsSupported => (HapticEffectFlags)SDL.HapticQuery(haptic);
+        public HapticEffectFlags EffectsSupported => (HapticEffectFlags)SDL.GetHapticFeatures(haptic);
 
         /// <summary>
         /// Opens a haptic device associated with a gamepad and returns a <see cref="Haptic"/> instance for it.
@@ -59,7 +58,7 @@
         /// <returns>A <see cref="Haptic"/> instance representing the haptic feedback device.</returns>
         public static Haptic OpenFromGamepad(Gamepad gamepad)
         {
-            return new(SDL.HapticOpenFromJoystick(gamepad.joystick));
+            return new(SDL.OpenHapticFromJoystick(gamepad.joystick));
         }
 
         /// <summary>
@@ -69,7 +68,7 @@
         /// <returns>A <see cref="Haptic"/> instance representing the haptic feedback device.</returns>
         public static Haptic OpenFromJoystick(Joystick joystick)
         {
-            return new(SDL.HapticOpenFromJoystick(joystick.joystick));
+            return new(SDL.OpenHapticFromJoystick(joystick.joystick));
         }
 
         /// <summary>
@@ -78,7 +77,7 @@
         /// <returns>A <see cref="Haptic"/> instance representing the haptic feedback device.</returns>
         public static Haptic OpenFromMouse()
         {
-            return new(SDL.HapticOpenFromMouse());
+            return new(SDL.OpenHapticFromMouse());
         }
 
         /// <summary>
@@ -86,9 +85,9 @@
         /// </summary>
         /// <param name="index">The index of the haptic device to open.</param>
         /// <returns>A <see cref="Haptic"/> instance representing the haptic feedback device.</returns>
-        public static Haptic OpenFromIndex(int index)
+        public static Haptic OpenFromIndex(uint index)
         {
-            return new(SDL.HapticOpen(index));
+            return new(SDL.OpenHaptic(index));
         }
     }
 }

--- a/Hexa.NET.KittyUI/Input/Helper.cs
+++ b/Hexa.NET.KittyUI/Input/Helper.cs
@@ -1,5 +1,7 @@
 ﻿namespace Hexa.NET.KittyUI.Input
 {
+    using Hexa.NET.SDL3;
+
     /// <summary>
     /// A utility class that provides conversion methods for translating between different input and SDL types.
     /// </summary>
@@ -10,7 +12,7 @@
         /// </summary>
         /// <param name="code">The SDL key code to convert.</param>
         /// <returns>The corresponding Key enum value.</returns>
-        public static Key Convert(SDL2.SDLKeyCode code)
+        public static Key Convert(int code)
         {
             return (Key)code;
         }
@@ -20,9 +22,9 @@
         /// </summary>
         /// <param name="code">The Key enum value to convert.</param>
         /// <returns>The corresponding SDL key code.</returns>
-        public static SDL2.SDLKeyCode ConvertBack(Key code)
+        public static int ConvertBack(Key code)
         {
-            return (SDL2.SDLKeyCode)code;
+            return (int)code;
         }
 
         /// <summary>
@@ -30,9 +32,9 @@
         /// </summary>
         /// <param name="gamepadAxis">The GamepadAxis enum value to convert.</param>
         /// <returns>The corresponding SDL GameControllerAxis.</returns>
-        public static SDL2.SDLGameControllerAxis ConvertBack(GamepadAxis gamepadAxis)
+        public static SDL3.SDLGamepadAxis ConvertBack(GamepadAxis gamepadAxis)
         {
-            return (SDL2.SDLGameControllerAxis)gamepadAxis;
+            return (SDL3.SDLGamepadAxis)gamepadAxis;
         }
 
         /// <summary>
@@ -40,7 +42,7 @@
         /// </summary>
         /// <param name="axis">The SDL GameControllerAxis to convert.</param>
         /// <returns>The corresponding GamepadAxis enum value.</returns>
-        public static GamepadAxis Convert(SDL2.SDLGameControllerAxis axis)
+        public static GamepadAxis Convert(SDL3.SDLGamepadAxis axis)
         {
             return (GamepadAxis)axis;
         }
@@ -50,9 +52,9 @@
         /// </summary>
         /// <param name="gamepadButton">The GamepadButton enum value to convert.</param>
         /// <returns>The corresponding SDL GameControllerButton.</returns>
-        public static SDL2.SDLGameControllerButton ConvertBack(GamepadButton gamepadButton)
+        public static SDL3.SDLGamepadButton ConvertBack(GamepadButton gamepadButton)
         {
-            return (SDL2.SDLGameControllerButton)gamepadButton;
+            return (SDL3.SDLGamepadButton)gamepadButton;
         }
 
         /// <summary>
@@ -60,7 +62,7 @@
         /// </summary>
         /// <param name="button">The SDL GameControllerButton to convert.</param>
         /// <returns>The corresponding GamepadButton enum value.</returns>
-        public static GamepadButton Convert(SDL2.SDLGameControllerButton button)
+        public static GamepadButton Convert(SDL3.SDLGamepadButton button)
         {
             return (GamepadButton)button;
         }
@@ -70,7 +72,7 @@
         /// </summary>
         /// <param name="gameControllerType">The SDL GameControllerType to convert.</param>
         /// <returns>The corresponding GamepadType enum value.</returns>
-        public static GamepadType Convert(SDL2.SDLGameControllerType gameControllerType)
+        public static GamepadType Convert(SDL3.SDLGamepadType gameControllerType)
         {
             return (GamepadType)gameControllerType;
         }
@@ -80,9 +82,9 @@
         /// </summary>
         /// <param name="gamepadSensorType">The GamepadSensorType enum value to convert.</param>
         /// <returns>The corresponding SDL SensorType.</returns>
-        public static SDL2.SDLSensorType ConvertBack(GamepadSensorType gamepadSensorType)
+        public static SDL3.SDLSensorType ConvertBack(GamepadSensorType gamepadSensorType)
         {
-            return (SDL2.SDLSensorType)gamepadSensorType;
+            return (SDL3.SDLSensorType)gamepadSensorType;
         }
 
         /// <summary>
@@ -90,7 +92,7 @@
         /// </summary>
         /// <param name="sensorType">The SDL SensorType to convert.</param>
         /// <returns>The corresponding GamepadSensorType enum value.</returns>
-        public static GamepadSensorType Convert(SDL2.SDLSensorType sensorType)
+        public static GamepadSensorType Convert(SDL3.SDLSensorType sensorType)
         {
             return (GamepadSensorType)sensorType;
         }
@@ -100,19 +102,19 @@
         /// </summary>
         /// <param name="joystickType">The SDL JoystickType to convert.</param>
         /// <returns>The corresponding JoystickType enum value.</returns>
-        public static JoystickType Convert(SDL2.SDLJoystickType joystickType)
+        public static JoystickType Convert(SDL3.SDLJoystickType joystickType)
         {
             return (JoystickType)joystickType;
         }
 
         /// <summary>
-        /// Converts an SDL JoystickPowerLevel to its corresponding JoystickPowerLevel enum value.
+        /// Converts an SDL PowerState to its corresponding PowerState enum value.
         /// </summary>
-        /// <param name="joystickPowerLevel">The SDL JoystickPowerLevel to convert.</param>
-        /// <returns>The corresponding JoystickPowerLevel enum value.</returns>
-        public static JoystickPowerLevel Convert(SDL2.SDLJoystickPowerLevel joystickPowerLevel)
+        /// <param name="powerState">The SDL PowerState to convert.</param>
+        /// <returns>The corresponding PowerState enum value.</returns>
+        public static PowerState Convert(SDL3.SDLPowerState powerState)
         {
-            return (JoystickPowerLevel)joystickPowerLevel;
+            return (PowerState)powerState;
         }
     }
 }

--- a/Hexa.NET.KittyUI/Input/Joystick.cs
+++ b/Hexa.NET.KittyUI/Input/Joystick.cs
@@ -1,10 +1,9 @@
 ﻿namespace Hexa.NET.KittyUI.Input
 {
     using Hexa.NET.KittyUI.Input.Events;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using System.Numerics;
-    using System.Text;
-    using static Hexa.NET.KittyUI.Extensions.SdlErrorHandlingExtensions;
+    using static Extensions.SdlErrorHandlingExtensions;
 
     /// <summary>
     /// Represents a generic delegate for handling joystick events.
@@ -43,50 +42,49 @@
         public Joystick(int id)
         {
             this.id = id;
-            joystick = SDL.JoystickOpen(id);
+            joystick = SDL.OpenJoystick(id);
             if (joystick == null)
+            {
                 SdlCheckError();
+            }
 
-            var axisCount = SDL.JoystickNumAxes(joystick);
+            var axisCount = SDL.GetNumJoystickAxes(joystick);
             for (int i = 0; i < axisCount; i++)
             {
                 short state;
-                SDL.JoystickGetAxisInitialState(joystick, i, &state);
+                SDL.GetJoystickAxisInitialState(joystick, i, &state);
                 axes.Add(i, state);
             }
 
-            var ballCount = SDL.JoystickNumBalls(joystick);
+            var ballCount = SDL.GetNumJoystickBalls(joystick);
             for (int i = 0; i < ballCount; i++)
             {
                 int x;
                 int y;
-                SDL.JoystickGetBall(joystick, i, &x, &y);
+                SDL.GetJoystickBall(joystick, i, &x, &y);
                 balls.Add(i, new(x, y));
             }
 
-            var buttonCount = SDL.JoystickNumButtons(joystick);
+            var buttonCount = SDL.GetNumJoystickButtons(joystick);
             for (int i = 0; i < buttonCount; i++)
             {
-                var state = (JoystickButtonState)SDL.JoystickGetButton(joystick, i);
+                var state = SDL.GetJoystickButton(joystick, i) ? JoystickButtonState.Down : JoystickButtonState.Up;
                 buttons.Add(i, state);
             }
 
-            var hatCount = SDL.JoystickNumHats(joystick);
+            var hatCount = SDL.GetNumJoystickHats(joystick);
             for (int i = 0; i < hatCount; i++)
             {
-                var state = (JoystickHatState)SDL.JoystickGetHat(joystick, i);
+                var state = (JoystickHatState)SDL.GetJoystickHat(joystick, i);
                 hats.Add(i, state);
             }
 
-            var guid = SDL.JoystickGetGUID(joystick);
+            var guid = SDL.GetJoystickGUID(joystick);
             SdlCheckError();
-            var buffer = AllocT<byte>(33);
-            SDL.JoystickGetGUIDString(guid, buffer, 33);
-            var size = StrLen(buffer);
-            var value = Encoding.ASCII.GetString(buffer, size - 1);
-            Free(buffer);
-            this.guid = value;
+            this.guid = (*(Guid*)&guid).ToString();
         }
+
+        protected uint Props => SDL.GetJoystickProperties(joystick);
 
         /// <summary>
         /// Gets the ID of the joystick.
@@ -100,9 +98,12 @@
         {
             get
             {
-                var name = SDL.JoystickNameS(joystick);
+                var name = SDL.GetJoystickNameS(joystick);
                 if (name == null)
+                {
                     SdlCheckError();
+                }
+
                 return name ?? string.Empty;
             }
         }
@@ -110,22 +111,22 @@
         /// <summary>
         /// Gets the vendor ID of the joystick.
         /// </summary>
-        public ushort Vendor => SDL.JoystickGetVendor(joystick);
+        public ushort Vendor => SDL.GetJoystickVendor(joystick);
 
         /// <summary>
         /// Gets the product ID of the joystick.
         /// </summary>
-        public ushort Product => SDL.JoystickGetProduct(joystick);
+        public ushort Product => SDL.GetJoystickProduct(joystick);
 
         /// <summary>
         /// Gets the product version of the joystick.
         /// </summary>
-        public ushort ProductVersion => SDL.JoystickGetProductVersion(joystick);
+        public ushort ProductVersion => SDL.GetJoystickProductVersion(joystick);
 
         /// <summary>
         /// Gets the serial number of the joystick.
         /// </summary>
-        public string Serial => SDL.JoystickGetSerialS(joystick);
+        public string Serial => SDL.GetJoystickSerialS(joystick);
 
         /// <summary>
         /// Gets the unique identifier (GUID) of the joystick.
@@ -135,22 +136,32 @@
         /// <summary>
         /// Gets a value indicating whether the joystick is attached and available.
         /// </summary>
-        public bool IsAttached => SDL.JoystickGetAttached(joystick) == SDLBool.True;
+        public bool IsAttached => SDL.JoystickConnected(joystick);
 
         /// <summary>
         /// Gets a value indicating whether the joystick is a virtual joystick.
         /// </summary>
-        public bool IsVirtual => SDL.JoystickIsVirtual(id) == SDLBool.True;
+        public bool IsVirtual => SDL.IsJoystickVirtual(id);
 
         /// <summary>
         /// Gets a value indicating whether the joystick has LED support.
         /// </summary>
-        public bool HasLED => SDL.JoystickHasLED(joystick) == SDLBool.True;
+        public bool HasLED => SDL.HasProperty(Props, SDL.SDL_PROP_JOYSTICK_CAP_RGB_LED_BOOLEAN);
+
+        /// <summary>
+        /// Gets a value indicating whether the joystick has rumble support.
+        /// </summary>
+        public bool HasRumble => SDL.HasProperty(Props, SDL.SDL_PROP_JOYSTICK_CAP_RUMBLE_BOOLEAN);
+
+        /// <summary>
+        /// Gets a value indicating whether the joystick has trigger rumble support.
+        /// </summary>
+        public bool HasTriggerRumble => SDL.HasProperty(Props, SDL.SDL_PROP_JOYSTICK_CAP_TRIGGER_RUMBLE_BOOLEAN);
 
         /// <summary>
         /// Gets the type of the joystick.
         /// </summary>
-        public JoystickType Type => Helper.Convert(SDL.JoystickGetType(joystick));
+        public JoystickType Type => Helper.Convert(SDL.GetJoystickType(joystick));
 
         /// <summary>
         /// Gets or sets the deadzone value for joystick axes.
@@ -160,12 +171,20 @@
         /// <summary>
         /// Gets or sets the player index assigned to the joystick.
         /// </summary>
-        public int PlayerIndex { get => SDL.JoystickGetPlayerIndex(joystick); set => SDL.JoystickSetPlayerIndex(joystick, value); }
+        public int PlayerIndex { get => SDL.GetJoystickPlayerIndex(joystick); set => SDL.SetJoystickPlayerIndex(joystick, value); }
 
         /// <summary>
         /// Gets the current power level of the joystick.
         /// </summary>
-        public JoystickPowerLevel PowerLevel => Helper.Convert(SDL.JoystickCurrentPowerLevel(joystick));
+        public PowerInfo PowerInfo
+        {
+            get
+            {
+                PowerInfo value;
+                value.State = Helper.Convert(SDL.GetJoystickPowerInfo(joystick, &value.Percent));
+                return value;
+            }
+        }
 
         /// <summary>
         /// Gets the state of joystick axes as a dictionary with axis ID and their values.
@@ -220,7 +239,7 @@
         /// <param name="durationMs">The duration of the rumble effect in milliseconds.</param>
         public void Rumble(ushort lowFreq, ushort highFreq, uint durationMs)
         {
-            SDL.JoystickRumble(joystick, lowFreq, highFreq, durationMs);
+            SDL.RumbleJoystick(joystick, lowFreq, highFreq, durationMs);
         }
 
         /// <summary>
@@ -231,7 +250,7 @@
         /// <param name="durationMs">The duration of the rumble effect in milliseconds.</param>
         public void RumbleTriggers(ushort left, ushort right, uint durationMs)
         {
-            SDL.JoystickRumbleTriggers(joystick, left, right, durationMs);
+            SDL.RumbleJoystickTriggers(joystick, left, right, durationMs);
         }
 
         /// <summary>
@@ -240,7 +259,7 @@
         /// <param name="color">A Vector4 specifying the LED color (red, green, blue, and alpha components).</param>
         public void SetLED(Vector4 color)
         {
-            SDL.JoystickSetLED(joystick, (byte)(color.X * 255), (byte)(color.Y * 255), (byte)(color.Z * 255));
+            SDL.SetJoystickLED(joystick, (byte)(color.X * 255), (byte)(color.Y * 255), (byte)(color.Z * 255));
         }
 
         /// <summary>
@@ -251,7 +270,7 @@
         /// <param name="blue">The blue color component (0 to 255).</param>
         public void SetLED(byte red, byte green, byte blue)
         {
-            SDL.JoystickSetLED(joystick, red, green, blue);
+            SDL.SetJoystickLED(joystick, red, green, blue);
         }
 
         internal (Joystick Joystick, JoystickAxisMotionEventArgs AxisMotionEventArgs)? OnAxisMotion(SDLJoyAxisEvent even)
@@ -333,18 +352,9 @@
         {
             if (!disposedValue)
             {
-                SDL.JoystickClose(joystick);
+                SDL.CloseJoystick(joystick);
                 disposedValue = true;
             }
-        }
-
-        /// <summary>
-        /// Finalizes an instance of the <see cref="Joystick"/> class.
-        /// </summary>
-        ~Joystick()
-        {
-            // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
-            Dispose(disposing: false);
         }
 
         /// <summary>
@@ -358,3 +368,4 @@
         }
     }
 }
+

--- a/Hexa.NET.KittyUI/Input/Joysticks.cs
+++ b/Hexa.NET.KittyUI/Input/Joysticks.cs
@@ -1,7 +1,7 @@
 ﻿namespace Hexa.NET.KittyUI.Input
 {
     using Hexa.NET.KittyUI.Input.Events;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using System.Runtime.CompilerServices;
 
     /// <summary>

--- a/Hexa.NET.KittyUI/Input/Keyboard.cs
+++ b/Hexa.NET.KittyUI/Input/Keyboard.cs
@@ -1,7 +1,7 @@
 ﻿namespace Hexa.NET.KittyUI.Input
 {
     using Hexa.NET.KittyUI.Input.Events;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using System;
     using System.Collections.Generic;
     using System.Runtime.CompilerServices;
@@ -19,7 +19,7 @@
         private static readonly string[] keyNames = new string[keys.Length];
         private static readonly Dictionary<Key, KeyState> states = new();
         private static readonly KeyboardEventArgs keyboardEventArgs = new();
-        private static readonly KeyboardCharEventArgs keyboardCharEventArgs = new();
+        private static readonly TextInputEventArgs keyboardCharEventArgs = new();
 
         /// <summary>
         /// Gets a read-only list of available keyboard keys.
@@ -42,52 +42,49 @@
         internal static unsafe void Init()
         {
             int numkeys;
-            byte* pKeys = SDL.GetKeyboardState(&numkeys);
+            bool* pKeys = SDL.GetKeyboardState(&numkeys);
 
             for (int i = 0; i < keys.Length; i++)
             {
                 Key key = keys[i];
                 keyNames[i] = SDL.GetKeyNameS((int)key);
-                var scancode = (Key)SDL.GetScancodeFromKey((int)key);
-                states.Add(key, (KeyState)pKeys[(int)scancode]);
+                var scancode = (Key)SDL.GetScancodeFromKey((int)key, null);
+                states.Add(key, pKeys[(int)scancode] ? KeyState.Down : KeyState.Up);
             }
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void OnKeyDown(SDLKeyboardEvent keyboardEvent)
         {
-            Key keyCode = (Key)SDL.GetKeyFromScancode(keyboardEvent.Keysym.Scancode);
+            Key keyCode = (Key)(keyboardEvent.Key);
             states[keyCode] = KeyState.Down;
             keyboardEventArgs.Timestamp = keyboardEvent.Timestamp;
             keyboardEventArgs.Handled = false;
             keyboardEventArgs.State = KeyState.Down;
             keyboardEventArgs.KeyCode = keyCode;
-            keyboardEventArgs.ScanCode = (ScanCode)keyboardEvent.Keysym.Scancode;
+            keyboardEventArgs.ScanCode = (ScanCode)keyboardEvent.Scancode;
             KeyDown?.Invoke(null, keyboardEventArgs);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void OnKeyUp(SDLKeyboardEvent keyboardEvent)
         {
-            Key keyCode = (Key)SDL.GetKeyFromScancode(keyboardEvent.Keysym.Scancode);
+            Key keyCode = (Key)keyboardEvent.Key;
             states[keyCode] = KeyState.Up;
             keyboardEventArgs.Timestamp = keyboardEvent.Timestamp;
             keyboardEventArgs.Handled = false;
             keyboardEventArgs.State = KeyState.Up;
             keyboardEventArgs.KeyCode = keyCode;
-            keyboardEventArgs.ScanCode = (ScanCode)keyboardEvent.Keysym.Scancode;
+            keyboardEventArgs.ScanCode = (ScanCode)keyboardEvent.Scancode;
             KeyUp?.Invoke(null, keyboardEventArgs);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        internal static void OnTextInput(SDLTextInputEvent textInputEvent)
+        internal static unsafe void OnTextInput(SDLTextInputEvent textInputEvent)
         {
             keyboardCharEventArgs.Timestamp = textInputEvent.Timestamp;
             keyboardCharEventArgs.Handled = false;
-            unsafe
-            {
-                keyboardCharEventArgs.Char = *(char*)&textInputEvent.Text_0;
-            }
+            keyboardCharEventArgs.Text = textInputEvent.Text;
             TextInput?.Invoke(null, keyboardCharEventArgs);
         }
 
@@ -109,7 +106,7 @@
         /// <summary>
         /// Event raised when text input is received from the keyboard.
         /// </summary>
-        public static event EventHandler<KeyboardCharEventArgs>? TextInput;
+        public static event EventHandler<TextInputEventArgs>? TextInput;
 
         /// <summary>
         /// Checks if a specific key is in the "up" state.

--- a/Hexa.NET.KittyUI/Input/Mouse.cs
+++ b/Hexa.NET.KittyUI/Input/Mouse.cs
@@ -1,8 +1,8 @@
 ﻿namespace Hexa.NET.KittyUI.Input
 {
-    using Hexa.NET.KittyUI.Input.Events;
     using Hexa.NET.Mathematics;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
+    using Hexa.NET.KittyUI.Input.Events;
     using System.Collections.Generic;
     using System.Numerics;
     using System.Runtime.CompilerServices;
@@ -16,19 +16,14 @@
         private static readonly MouseButton[] buttons = Enum.GetValues<MouseButton>();
         private static readonly string[] buttonNames = Enum.GetNames<MouseButton>();
 
-        private static readonly MouseButtonState[] states;
+        private static readonly Dictionary<MouseButton, MouseButtonState> states = new();
         private static readonly MouseMotionEventArgs motionEventArgs = new();
         private static readonly MouseButtonEventArgs buttonEventArgs = new();
         private static readonly MouseWheelEventArgs wheelEventArgs = new();
 
-        private static Point2 pos;
+        private static Vector2 pos;
         private static Vector2 delta;
         private static Vector2 deltaWheel;
-
-        static Mouse()
-        {
-            states = new MouseButtonState[buttons.Length];
-        }
 
         /// <summary>
         /// Initializes the mouse input system.
@@ -38,29 +33,29 @@
             pos = default;
             SDL.GetMouseState(ref pos.X, ref pos.Y);
 
-            uint state = SDL.GetMouseState(null, null);
+            uint state = (uint)SDL.GetMouseState(null, null);
             uint maskLeft = unchecked(1 << (int)MouseButton.Left - 1);
             uint maskMiddle = unchecked(1 << (int)MouseButton.Middle - 1);
             uint maskRight = unchecked(1 << (int)MouseButton.Right - 1);
             uint maskX1 = unchecked(1 << (int)MouseButton.X1 - 1);
             uint maskX2 = unchecked(1 << (int)MouseButton.X2 - 1);
-            states[0] = (MouseButtonState)(state & maskLeft);
-            states[1] = (MouseButtonState)(state & maskMiddle);
-            states[2] = (MouseButtonState)(state & maskRight);
-            states[3] = (MouseButtonState)(state & maskX1);
-            states[4] = (MouseButtonState)(state & maskX2);
+            states.Add(MouseButton.Left, (MouseButtonState)(state & maskLeft));
+            states.Add(MouseButton.Middle, (MouseButtonState)(state & maskMiddle));
+            states.Add(MouseButton.Right, (MouseButtonState)(state & maskRight));
+            states.Add(MouseButton.X1, (MouseButtonState)(state & maskX1));
+            states.Add(MouseButton.X2, (MouseButtonState)(state & maskX2));
         }
 
         /// <summary>
         /// Gets the global mouse position.
         /// </summary>
-        public static Point2 Global
+        public static Vector2 Global
         {
             get
             {
-                int x, y;
+                float x, y;
                 SDL.GetGlobalMouseState(&x, &y);
-                return new Point2(x, y);
+                return new Vector2(x, y);
             }
         }
 
@@ -72,6 +67,7 @@
         /// <summary>
         /// Gets the mouse movement delta.
         /// </summary>
+        /// <remarks>No need to multiply by <see cref="Time.Delta"/>, this value is frame-rate independent.</remarks>
         public static Vector2 Delta => delta;
 
         /// <summary>
@@ -92,7 +88,7 @@
         /// <summary>
         /// Gets the current state of mouse buttons.
         /// </summary>
-        public static MouseButtonState[] States => states;
+        public static IDictionary<MouseButton, MouseButtonState> States => states;
 
         /// <summary>
         /// Event triggered when the mouse is moved.
@@ -121,12 +117,8 @@
         /// <returns><c>true</c> if the button is in the "Down" state, otherwise <c>false</c>.</returns>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsDown(MouseButton button)
-        {        
-            if (button < MouseButton.Left || button >= MouseButton.X2)
-            {
-                return false;
-            }   
-            return states[(int)button - 1] == MouseButtonState.Down;
+        {
+            return states[button] == MouseButtonState.Down;
         }
 
         /// <summary>
@@ -137,20 +129,21 @@
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static bool IsUp(MouseButton button)
         {
-            return states[(int)button - 1] == MouseButtonState.Down;
+            return states[button] == MouseButtonState.Down;
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void OnButtonDown(SDLMouseButtonEvent mouseButtonEvent)
         {
             MouseButton button = (MouseButton)mouseButtonEvent.Button;
-            states[(int)button - 1] = MouseButtonState.Down;
+            states[button] = MouseButtonState.Down;
             buttonEventArgs.Timestamp = mouseButtonEvent.Timestamp;
             buttonEventArgs.Handled = false;
             buttonEventArgs.MouseId = mouseButtonEvent.Which;
             buttonEventArgs.Button = button;
             buttonEventArgs.State = MouseButtonState.Down;
             buttonEventArgs.Clicks = mouseButtonEvent.Clicks;
+            buttonEventArgs.Position = new(mouseButtonEvent.X, mouseButtonEvent.Y);
             ButtonDown?.Invoke(null, buttonEventArgs);
         }
 
@@ -158,13 +151,14 @@
         internal static void OnButtonUp(SDLMouseButtonEvent mouseButtonEvent)
         {
             MouseButton button = (MouseButton)mouseButtonEvent.Button;
-            states[(int)button - 1] = MouseButtonState.Up;
+            states[button] = MouseButtonState.Up;
             buttonEventArgs.Timestamp = mouseButtonEvent.Timestamp;
             buttonEventArgs.Handled = false;
             buttonEventArgs.MouseId = mouseButtonEvent.Which;
             buttonEventArgs.Button = button;
             buttonEventArgs.State = MouseButtonState.Up;
             buttonEventArgs.Clicks = mouseButtonEvent.Clicks;
+            buttonEventArgs.Position = new(mouseButtonEvent.X, mouseButtonEvent.Y);
             ButtonUp?.Invoke(null, buttonEventArgs);
         }
 
@@ -176,12 +170,11 @@
                 return;
             }
 
-            delta += new Vector2(mouseMotionEvent.Xrel, mouseMotionEvent.Yrel);
             motionEventArgs.Timestamp = mouseMotionEvent.Timestamp;
             motionEventArgs.Handled = false;
             motionEventArgs.MouseId = mouseMotionEvent.Which;
-            motionEventArgs.RelX = delta.X;
-            motionEventArgs.RelY = delta.Y;
+            motionEventArgs.RelX = mouseMotionEvent.Xrel;
+            motionEventArgs.RelY = mouseMotionEvent.Yrel;
             motionEventArgs.X = pos.X;
             motionEventArgs.Y = pos.Y;
             Moved?.Invoke(null, motionEventArgs);
@@ -200,9 +193,16 @@
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void Poll()
+        {
+            var old = pos;
+            SDL.GetGlobalMouseState(ref pos.X, ref pos.Y);
+            delta = pos - old;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         internal static void Flush()
         {
-            SDL.GetMouseState(ref pos.X, ref pos.Y);
             delta = Vector2.Zero;
             deltaWheel = Vector2.Zero;
         }

--- a/Hexa.NET.KittyUI/Input/PowerInfo.cs
+++ b/Hexa.NET.KittyUI/Input/PowerInfo.cs
@@ -1,0 +1,8 @@
+﻿namespace Hexa.NET.KittyUI.Input
+{
+    public struct PowerInfo
+    {
+        public int Percent;
+        public PowerState State;
+    }
+}

--- a/Hexa.NET.KittyUI/Input/PowerState.cs
+++ b/Hexa.NET.KittyUI/Input/PowerState.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Represents the power level of a joystick.
     /// </summary>
-    public enum JoystickPowerLevel
+    public enum PowerState
     {
         /// <summary>
         /// The power level is unknown.

--- a/Hexa.NET.KittyUI/Input/TouchDevice.cs
+++ b/Hexa.NET.KittyUI/Input/TouchDevice.cs
@@ -1,9 +1,7 @@
 ﻿namespace Hexa.NET.KittyUI.Input
 {
-    using Hexa.NET.KittyUI.Debugging;
+    using Hexa.NET.SDL3;
     using Hexa.NET.KittyUI.Input.Events;
-    using Hexa.NET.SDL2;
-    using static Hexa.NET.KittyUI.Extensions.SdlErrorHandlingExtensions;
 
     /// <summary>
     /// Represents a generic delegate for handling events in the TouchDevice class.
@@ -28,68 +26,21 @@
         private readonly TouchMotionEventArgs touchMotionEventArgs = new();
 
         /// <summary>
-        /// Initializes a new instance of the <see cref="TouchDevice"/> class using the specified index.
-        /// </summary>
-        /// <param name="id"></param>
-        /// <param name="index">The index of the touch device.</param>
-        public TouchDevice(long id, int index)
-        {
-            byte* pName = SDL.GetTouchName(index);
-            if (pName == null)
-            {
-                SdlLogWarn();
-                name = "Unknown";
-            }
-            else
-            {
-                name = ToStringFromUTF8(pName)!;
-            }
-
-            type = (TouchDeviceType)SDL.GetTouchDeviceType(id);
-
-            var fingerCount = SDL.GetNumTouchFingers(id);
-            if (fingerCount == 0)
-            {
-                SdlLogWarn();
-            }
-            fingers = new Finger[fingerCount];
-            for (int i = 0; i < fingerCount; i++)
-            {
-                var finger = SDL.GetTouchFinger(id, i);
-                if (finger == null)
-                {
-                    SdlLogger.Warn($"No finger found at index {i} for touch device {id}.");
-                    continue;
-                }
-                fingers[i] = new(finger);
-                fingerIdToIndex.Add(finger->Id, i);
-            }
-        }
-
-        /// <summary>
         /// Initializes a new instance of the <see cref="TouchDevice"/> class using the specified device ID.
         /// </summary>
         /// <param name="id">The ID of the touch device.</param>
         public TouchDevice(long id)
         {
             this.id = id;
-            name = "Unknown";
+            name = SDL.GetTouchDeviceNameS(id);
             type = (TouchDeviceType)SDL.GetTouchDeviceType(id);
 
-            var fingerCount = SDL.GetNumTouchFingers(id);
-            if (fingerCount == 0)
-            {
-                SdlLogWarn();
-            }
+            int fingerCount;
+            var sdlFingers = SDL.GetTouchFingers(id, &fingerCount);
             fingers = new Finger[fingerCount];
             for (int i = 0; i < fingerCount; i++)
             {
-                var finger = SDL.GetTouchFinger(id, i);
-                if (finger == null)
-                {
-                    SdlLogger.Warn($"No finger found at index {i} for touch device {id}.");
-                    continue;
-                }
+                var finger = sdlFingers[i];
                 fingers[i] = new(finger);
                 fingerIdToIndex.Add(finger->Id, i);
             }
@@ -134,16 +85,15 @@
         {
             touchEventArgs.Timestamp = evnt.Timestamp;
             touchEventArgs.TouchDeviceId = id;
-            touchEventArgs.FingerId = evnt.FingerId;
+            touchEventArgs.FingerId = evnt.FingerID;
             touchEventArgs.Pressure = evnt.Pressure;
             touchEventArgs.X = evnt.X;
             touchEventArgs.Y = evnt.Y;
             touchEventArgs.State = FingerState.Up;
 
-            var idx = fingerIdToIndex[evnt.FingerId];
+            var idx = fingerIdToIndex[evnt.FingerID];
             var finger = fingers[idx];
             finger.OnFingerUp(touchEventArgs);
-            ImGuiDebugTools.WriteLine($"Up {evnt.FingerId}, {evnt.X}, {evnt.Y}");
 
             TouchUp?.Invoke(this, touchEventArgs);
             return (this, touchEventArgs);
@@ -153,16 +103,15 @@
         {
             touchEventArgs.Timestamp = evnt.Timestamp;
             touchEventArgs.TouchDeviceId = id;
-            touchEventArgs.FingerId = evnt.FingerId;
+            touchEventArgs.FingerId = evnt.FingerID;
             touchEventArgs.Pressure = evnt.Pressure;
             touchEventArgs.X = evnt.X;
             touchEventArgs.Y = evnt.Y;
             touchEventArgs.State = FingerState.Down;
 
-            var idx = fingerIdToIndex[evnt.FingerId];
+            var idx = fingerIdToIndex[evnt.FingerID];
             var finger = fingers[idx];
             finger.OnFingerDown(touchEventArgs);
-            ImGuiDebugTools.WriteLine($"Down {evnt.FingerId}, {evnt.X}, {evnt.Y}");
 
             TouchDown?.Invoke(this, touchEventArgs);
             return (this, touchEventArgs);
@@ -172,17 +121,16 @@
         {
             touchMotionEventArgs.Timestamp = evnt.Timestamp;
             touchMotionEventArgs.TouchDeviceId = id;
-            touchMotionEventArgs.FingerId = evnt.FingerId;
+            touchMotionEventArgs.FingerId = evnt.FingerID;
             touchMotionEventArgs.Pressure = evnt.Pressure;
             touchMotionEventArgs.X = evnt.X;
             touchMotionEventArgs.Y = evnt.Y;
             touchMotionEventArgs.Dx = evnt.Dx;
             touchMotionEventArgs.Dy = evnt.Dy;
 
-            var idx = fingerIdToIndex[evnt.FingerId];
+            var idx = fingerIdToIndex[evnt.FingerID];
             var finger = fingers[idx];
             finger.OnFingerMotion(touchMotionEventArgs);
-            ImGuiDebugTools.WriteLine($"Motion {evnt.FingerId}, {evnt.X}, {evnt.Y}, {evnt.Pressure}");
 
             TouchMotion?.Invoke(this, touchMotionEventArgs);
             return (this, touchMotionEventArgs);

--- a/Hexa.NET.KittyUI/Input/TouchDevices.cs
+++ b/Hexa.NET.KittyUI/Input/TouchDevices.cs
@@ -1,8 +1,7 @@
 ﻿namespace Hexa.NET.KittyUI.Input
 {
     using Hexa.NET.KittyUI.Input.Events;
-    using Hexa.NET.SDL2;
-    using static Hexa.NET.KittyUI.Extensions.SdlErrorHandlingExtensions;
+    using Hexa.NET.SDL3;
 
     /// <summary>
     /// Provides functionality to manage touch devices.
@@ -47,13 +46,14 @@
         /// <summary>
         /// Initializes the touch device management system.
         /// </summary>
-        internal static void Init()
+        internal static unsafe void Init()
         {
-            var touchDeviceCount = SDL.GetNumTouchDevices();
+            int touchDeviceCount;
+            long* devices = SDL.GetTouchDevices(&touchDeviceCount);
 
             for (int i = 0; i < touchDeviceCount; i++)
             {
-                AddTouchDeviceFromIndex(i);
+                AddTouchDevice(devices[i]);
             }
         }
 
@@ -67,18 +67,9 @@
             return idToTouch[touchDeviceId];
         }
 
-        internal static TouchDevice? AddTouchDeviceFromIndex(int index)
+        internal static TouchDevice AddTouchDevice(int index)
         {
-            long touchId = SDL.GetTouchDevice(index);
-            
-            if (touchId == 0)
-            {
-                SdlLogger.Warn($"Touch device index {index}, id ({touchId}) is invalid, ignoring call.");
-                SdlLogWarn();
-                return null;
-            }
-
-            TouchDevice dev = new(touchId, index);
+            TouchDevice dev = new(index);
             touchDevices.Add(dev);
             idToTouch.Add(dev.Id, dev);
             touchDeviceEventArgs.TouchDeviceId = dev.Id;
@@ -86,36 +77,14 @@
             return dev;
         }
 
-        internal static TouchDevice? AddTouchDeviceFromId(long touchId)
+        internal static TouchDevice AddTouchDevice(long touchId)
         {
-            if (touchId == 0)
-            {
-                // do not log here to avoid log spam.
-                return null;
-            }
-
-            var index = FindIndex(touchId);
-
-            TouchDevice dev = new(touchId, index);
+            TouchDevice dev = new(touchId);
             touchDevices.Add(dev);
             idToTouch.Add(touchId, dev);
             touchDeviceEventArgs.TouchDeviceId = dev.Id;
             TouchDeviceAdded?.Invoke(dev, touchDeviceEventArgs);
             return dev;
-        }
-
-        internal static int FindIndex(long id)
-        {
-            var touchDeviceCount = SDL.GetNumTouchDevices();
-            for (int i = 0; i < touchDeviceCount; i++)
-            {
-                long currentDeviceId = SDL.GetTouchDevice(i);
-                if (currentDeviceId == id)
-                {
-                    return i;
-                }
-            }
-            return -1;
         }
 
         internal static bool RemoveTouchDevice(long touchId)
@@ -131,35 +100,31 @@
             return false;
         }
 
-        internal static TouchDevice? AddOrGetTouch(long id)
+        internal static TouchDevice AddOrGetTouch(long id)
         {
-            if (id == 0) return null;
             if (idToTouch.TryGetValue(id, out TouchDevice? dev))
             {
                 return dev;
             }
-            return AddTouchDeviceFromId(id);
+            return AddTouchDevice(id);
         }
 
         internal static void FingerUp(SDLTouchFingerEvent evnt)
         {
-            var result = AddOrGetTouch(evnt.TouchId)?.OnFingerUp(evnt);
-            if (!result.HasValue) return;
-            TouchUp?.Invoke(result.Value.Item1, result.Value.Item2);
+            var result = AddOrGetTouch(evnt.TouchID).OnFingerUp(evnt);
+            TouchUp?.Invoke(result.Item1, result.Item2);
         }
 
         internal static void FingerDown(SDLTouchFingerEvent evnt)
         {
-            var result = AddOrGetTouch(evnt.TouchId)?.OnFingerDown(evnt);
-            if (!result.HasValue) return;
-            TouchDown?.Invoke(result.Value.Item1, result.Value.Item2);
+            var result = AddOrGetTouch(evnt.TouchID).OnFingerDown(evnt);
+            TouchDown?.Invoke(result.Item1, result.Item2);
         }
 
         internal static void FingerMotion(SDLTouchFingerEvent evnt)
         {
-            var result = AddOrGetTouch(evnt.TouchId)?.OnFingerMotion(evnt);
-            if (!result.HasValue) return;
-            TouchMotion?.Invoke(result.Value.Item1, result.Value.Item2);
+            var result = AddOrGetTouch(evnt.TouchID).OnFingerMotion(evnt);
+            TouchMotion?.Invoke(result.Item1, result.Item2);
         }
     }
 }

--- a/Hexa.NET.KittyUI/OpenGL/UploadQueue.cs
+++ b/Hexa.NET.KittyUI/OpenGL/UploadQueue.cs
@@ -11,7 +11,7 @@
 #endif
 
     using Hexa.NET.KittyUI.Windows;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using Hexa.NET.Utilities;
     using System.Collections.Concurrent;
     using System.Threading;
@@ -33,7 +33,7 @@
         public UploadQueue(HexaGen.Runtime.IGLContext mainContext, IWindow window)
         {
             mainContext.MakeCurrent();
-            SDL.GLSetAttribute(SDLGLattr.GlShareWithCurrentContext, 1);
+            SDL.GLSetAttribute(SDLGLAttr.ShareWithCurrentContext, 1);
             context = window.OpenGLCreateContext();
 
             mainContext.MakeCurrent();

--- a/Hexa.NET.KittyUI/UI/ITitleBar.cs
+++ b/Hexa.NET.KittyUI/UI/ITitleBar.cs
@@ -1,5 +1,5 @@
 using Hexa.NET.KittyUI.Windows;
-using Hexa.NET.SDL2;
+using Hexa.NET.SDL3;
 
 namespace Hexa.NET.KittyUI.UI;
 

--- a/Hexa.NET.KittyUI/UI/TitleBar.cs
+++ b/Hexa.NET.KittyUI/UI/TitleBar.cs
@@ -7,7 +7,7 @@
     using Hexa.NET.KittyUI.Native.X11;
     using Hexa.NET.KittyUI.Windows;
     using Hexa.NET.Mathematics;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using System;
     using System.Numerics;
     using System.Runtime.InteropServices;
@@ -420,7 +420,7 @@
         private Vector2 titleBarPos;
         private Vector2 titleBarSize;
         private int titleBarHeight = 30;
-        private Point2 mousePos;
+        private Vector2 mousePos;
         private Vector2 cursorPos;
         private float buttonSize = 50;
 

--- a/Hexa.NET.KittyUI/Windows/Clipboard.cs
+++ b/Hexa.NET.KittyUI/Windows/Clipboard.cs
@@ -1,6 +1,6 @@
 ﻿namespace Hexa.NET.KittyUI.Windows
 {
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
 
     public static unsafe class Clipboard
     {

--- a/Hexa.NET.KittyUI/Windows/CoreWindow.cs
+++ b/Hexa.NET.KittyUI/Windows/CoreWindow.cs
@@ -20,7 +20,7 @@
     using Hexa.NET.KittyUI.Windows.Events;
     using Hexa.NET.Logging;
     using Hexa.NET.Mathematics;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using HexaGen.Runtime;
     using System;
     using System.Runtime.CompilerServices;
@@ -28,6 +28,7 @@
     using System.Text;
     using static Hexa.NET.KittyUI.Extensions.SdlErrorHandlingExtensions;
     using Key = Input.Key;
+    using Hexa.NET.KittyUI.Extensions;
 
     public unsafe class CoreWindow : IWindow
     {
@@ -50,7 +51,7 @@
         private readonly TakeFocusEventArgs takeFocusEventArgs = new();
         private readonly HitTestEventArgs hitTestEventArgs = new();
         private readonly KeyboardEventArgs keyboardEventArgs = new();
-        private readonly KeyboardCharEventArgs keyboardCharEventArgs = new();
+        private readonly TextInputEventArgs keyboardCharEventArgs = new();
         private readonly MouseButtonEventArgs mouseButtonEventArgs = new();
         private readonly MouseMotionEventArgs mouseMotionEventArgs = new();
         private readonly MouseWheelEventArgs mouseWheelEventArgs = new();
@@ -96,6 +97,7 @@
 
         private void PlatformConstruct(SDLWindowFlags windowFlags)
         {
+            Application.EarlyInit();
             if (created)
             {
                 return;
@@ -114,7 +116,7 @@
             byte[] bytes = Encoding.UTF8.GetBytes(title);
             byte* ptr = (byte*)Unsafe.AsPointer(ref bytes[0]);
 
-            windowFlags |= SDLWindowFlags.Hidden | SDLWindowFlags.AllowHighdpi;
+            windowFlags |= SDLWindowFlags.Hidden | SDLWindowFlags.HighPixelDensity;
 
             switch (backend)
             {
@@ -131,19 +133,33 @@
                     break;
             }
 
-            window = SdlCheckError(SDL.CreateWindow(ptr, x, y, width, height, (uint)windowFlags));
-
+            uint display = SDL.GetPrimaryDisplay();
+            float scale = SDL.GetDisplayContentScale(display);
+            if (scale == 0)
+            {
+                SdlCheckError();
+            }
+            window = SdlCheckError(SDL.CreateWindow(ptr, (int)(width * scale), (int)(height * scale), windowFlags));
+            SDL.SetWindowPosition(window, x, y);
             WindowID = SDL.GetWindowID(window).SdlThrowIf();
 
             int w;
             int h;
             SDL.GetWindowSize(window, &w, &h);
 
-            cursors = (SDLCursor**)AllocArray((uint)SDLSystemCursor.NumSystemCursors);
-            for (SDLSystemCursor i = 0; i < SDLSystemCursor.NumSystemCursors; i++)
-            {
-                cursors[(int)i] = SdlCheckError(SDL.CreateSystemCursor(SDLSystemCursor.Arrow));
-            }
+            cursors = (SDLCursor**)AllocArray((uint)SDLSystemCursor.Count);
+            cursors[(int)CursorType.Arrow] = SdlCheckError(SDL.CreateSystemCursor(SDLSystemCursor.Default));
+            cursors[(int)CursorType.IBeam] = SdlCheckError(SDL.CreateSystemCursor(SDLSystemCursor.Text));
+            cursors[(int)CursorType.Wait] = SdlCheckError(SDL.CreateSystemCursor(SDLSystemCursor.Wait));
+            cursors[(int)CursorType.Crosshair] = SdlCheckError(SDL.CreateSystemCursor(SDLSystemCursor.Crosshair));
+            cursors[(int)CursorType.WaitArrow] = SdlCheckError(SDL.CreateSystemCursor(SDLSystemCursor.Wait));
+            cursors[(int)CursorType.SizeNWSE] = SdlCheckError(SDL.CreateSystemCursor(SDLSystemCursor.NwseResize));
+            cursors[(int)CursorType.SizeNESW] = SdlCheckError(SDL.CreateSystemCursor(SDLSystemCursor.NeswResize));
+            cursors[(int)CursorType.SizeWE] = SdlCheckError(SDL.CreateSystemCursor(SDLSystemCursor.EwResize));
+            cursors[(int)CursorType.SizeNS] = SdlCheckError(SDL.CreateSystemCursor(SDLSystemCursor.NsResize));
+            cursors[(int)CursorType.SizeAll] = SdlCheckError(SDL.CreateSystemCursor(SDLSystemCursor.Crosshair));
+            cursors[(int)CursorType.No] = SdlCheckError(SDL.CreateSystemCursor(SDLSystemCursor.NotAllowed));
+            cursors[(int)CursorType.Hand] = SdlCheckError(SDL.CreateSystemCursor(SDLSystemCursor.Pointer));
 
             Width = w;
             Height = h;
@@ -179,16 +195,16 @@
                     if (OperatingSystem.IsMacOS())
                     {
                         // Set max OpenGL version to 4.1 for macOS
-                        SDL.GLSetAttribute(SDLGLattr.GlContextMajorVersion, 4);
-                        SDL.GLSetAttribute(SDLGLattr.GlContextMinorVersion, 1);
+                        SDL.GLSetAttribute(SDLGLAttr.ContextMajorVersion, 4);
+                        SDL.GLSetAttribute(SDLGLAttr.ContextMinorVersion, 1);
                     }
                     else
                     {
                         // Set to OpenGL 4.5 for other platforms
-                        SDL.GLSetAttribute(SDLGLattr.GlContextMajorVersion, 4);
-                        SDL.GLSetAttribute(SDLGLattr.GlContextMinorVersion, 5);
+                        SDL.GLSetAttribute(SDLGLAttr.ContextMajorVersion, 4);
+                        SDL.GLSetAttribute(SDLGLAttr.ContextMinorVersion, 5);
                     }
-                    SDL.GLSetAttribute(SDLGLattr.GlContextProfileMask, (int)SDLGLprofile.GlContextProfileCore);
+                    SDL.GLSetAttribute(SDLGLAttr.ContextProfileMask, SDL.SDL_GL_CONTEXT_PROFILE_CORE);
                     if (!OpenGLAdapter.Initialized)
                     {
                         OpenGLAdapter.Init(this);
@@ -197,7 +213,7 @@
                     }
                     else
                     {
-                        SDL.GLSetAttribute(SDLGLattr.GlShareWithCurrentContext, 1);
+                        SDL.GLSetAttribute(SDLGLAttr.ShareWithCurrentContext, 1);
                         OpenGLAdapter.Context.MakeCurrent();
                         GLContext = OpenGLCreateContext();
                         GLContext.MakeCurrent();
@@ -235,19 +251,24 @@
         public void ReleaseCapture()
         {
             Logger.ThrowIf(destroyed, "The window is already destroyed");
-            SDL.CaptureMouse(SDLBool.False);
+            SDL.CaptureMouse(false);
         }
 
         public void Capture()
         {
             Logger.ThrowIf(destroyed, "The window is already destroyed");
-            SDL.CaptureMouse(SDLBool.True);
+            SDL.CaptureMouse(true);
         }
 
-        public void Fullscreen(FullscreenMode mode)
+        ///<summary>
+        /// Sets the window to Fullscreen mode.
+        ///</summary>
+        ///<param name="mode">The Fullscreen mode to set.</param>
+        ///<exception cref="InvalidOperationException">Thrown when the window is already destroyed.</exception>
+        public void Fullscreen(bool mode)
         {
             Logger.ThrowIf(destroyed, "The window is already destroyed");
-            SDL.SetWindowFullscreen(window, (uint)mode);
+            SDL.SetWindowFullscreen(window, mode);
         }
 
         public bool VSync
@@ -264,19 +285,32 @@
             }
         }
 
+        public void StartTextInput()
+        {
+            SDL.StartTextInput(window);
+        }
+
+        public void StopTextInput()
+        {
+            SDL.StopTextInput(window);
+        }
+
+        public void SetTextInputRect(Rectangle rect, CursorType type)
+        {
+            SDLRect sdlRect = new(rect.Left, rect.Top, rect.Size.X, rect.Size.Y);
+            SDL.SetTextInputArea(window, &sdlRect, (int)type);
+        }
+
         [SupportedOSPlatform("windows")]
         public nint GetHWND()
         {
-            SDLSysWMInfo wmInfo;
-            SDL.GetVersion(&wmInfo.Version);
-            SDL.GetWindowWMInfo(window, &wmInfo);
-            return wmInfo.Info.Win.Window;
+            return (nint)SDL.GetPointerProperty(SDL.GetWindowProperties(window), SDL.SDL_PROP_WINDOW_WIN32_HWND_POINTER, null);
         }
 
         //public bool VulkanCreateSurface(VkHandle vkHandle, VkNonDispatchableHandle* vkNonDispatchableHandle)
         //{
         //    Logger.ThrowIf(destroyed, "The window is already destroyed");
-        //    return SDL.VulkanCreateSurface(window, vkHandle.Handle, (VkSurfaceKHR*)vkNonDispatchableHandle) == SDLBool.True;
+        //    return SDL.VulkanCreateSurface(window, vkHandle.Handle, (VkSurfaceKHR*)vkNonDispatchableHandle) == true;
         //}
 
         public IGLContext OpenGLCreateContext()
@@ -286,6 +320,16 @@
         }
 
         public SDLWindow* GetWindow() => window;
+
+        public uint Properties => SDL.GetWindowProperties(window);
+
+        public bool HDREnabled => SDL.GetBooleanProperty(Properties, SDL.SDL_PROP_WINDOW_HDR_ENABLED_BOOLEAN, false);
+
+        public float SDRWhiteLevel => SDL.GetFloatProperty(Properties, SDL.SDL_PROP_WINDOW_SDR_WHITE_LEVEL_FLOAT, 0);
+
+        public float HDRHeadroom => SDL.GetFloatProperty(Properties, SDL.SDL_PROP_WINDOW_HDR_HEADROOM_FLOAT, 0);
+
+        public float ContentScale => SDL.GetWindowDisplayScale(window);
 
         public uint WindowID { get; private set; }
 
@@ -454,7 +498,7 @@
             {
                 Logger.ThrowIf(destroyed, "The window is already destroyed");
                 lockCursor = value;
-                SDL.SetRelativeMouseMode(value ? SDLBool.True : SDLBool.False);
+                SDL.SetWindowRelativeMouseMode(window, value);
             }
         }
 
@@ -465,7 +509,7 @@
             {
                 Logger.ThrowIf(destroyed, "The window is already destroyed");
                 resizable = value;
-                SDL.SetWindowResizable(window, value ? SDLBool.True : SDLBool.False);
+                SDL.SetWindowResizable(window, value);
             }
         }
 
@@ -476,7 +520,7 @@
             {
                 Logger.ThrowIf(destroyed, "The window is already destroyed");
                 bordered = value;
-                SDL.SetWindowBordered(window, value ? SDLBool.True : SDLBool.False);
+                SDL.SetWindowBordered(window, value);
             }
         }
 
@@ -487,11 +531,11 @@
             get
             {
                 Logger.ThrowIf(destroyed, "The window is already destroyed");
-                SDLSysWMInfo wmInfo;
-                SDL.GetVersion(&wmInfo.Version);
-                SDL.GetWindowWMInfo(window, &wmInfo);
 
-                return (wmInfo.Info.X11.Display, (nuint)wmInfo.Info.X11.Window);
+                var props = SDL.GetWindowProperties(window);
+                var display = (nint)SDL.GetPointerProperty(props, SDL.SDL_PROP_WINDOW_X11_DISPLAY_POINTER, null);
+                var surface = (nuint)SDL.GetNumberProperty(props, SDL.SDL_PROP_WINDOW_X11_WINDOW_NUMBER, 0);
+                return (display, surface);
             }
         }
 
@@ -502,11 +546,11 @@
             get
             {
                 Logger.ThrowIf(destroyed, "The window is already destroyed");
-                SDLSysWMInfo wmInfo;
-                SDL.GetVersion(&wmInfo.Version);
-                SDL.GetWindowWMInfo(window, &wmInfo);
 
-                return (wmInfo.Info.Wayland.Display, wmInfo.Info.Wayland.Surface);
+                var props = SDL.GetWindowProperties(window);
+                var display = (nint)SDL.GetPointerProperty(props, SDL.SDL_PROP_WINDOW_WAYLAND_DISPLAY_POINTER, null);
+                var surface = (nint)SDL.GetPointerProperty(props, SDL.SDL_PROP_WINDOW_WAYLAND_SURFACE_POINTER, null);
+                return (display, surface);
             }
         }
 
@@ -519,11 +563,12 @@
             get
             {
                 Logger.ThrowIf(destroyed, "The window is already destroyed");
-                SDLSysWMInfo wmInfo;
-                SDL.GetVersion(&wmInfo.Version);
-                SDL.GetWindowWMInfo(window, &wmInfo);
 
-                return (wmInfo.Info.Win.Window, wmInfo.Info.Win.Hdc, wmInfo.Info.Win.HInstance);
+                var props = SDL.GetWindowProperties(window);
+                var hwnd = (nint)SDL.GetPointerProperty(props, SDL.SDL_PROP_WINDOW_WIN32_HWND_POINTER, null);
+                var hdc = (nint)SDL.GetPointerProperty(props, SDL.SDL_PROP_WINDOW_WIN32_HDC_POINTER, null);
+                var instance = (nint)SDL.GetPointerProperty(props, SDL.SDL_PROP_WINDOW_WIN32_INSTANCE_POINTER, null);
+                return (hwnd, hdc, instance);
             }
         }
 
@@ -640,7 +685,7 @@
         /// <summary>
         /// Event triggered when a character input is received from the keyboard.
         /// </summary>
-        public event EventHandler<KeyboardCharEventArgs>? KeyboardCharInput;
+        public event EventHandler<TextInputEventArgs>? KeyboardCharInput;
 
         /// <summary>
         /// Event triggered when a mouse button input is received.
@@ -847,7 +892,7 @@
         /// Raises the <see cref="KeyboardCharInput"/> event.
         /// </summary>
         /// <param name="args">The event arguments.</param>
-        protected virtual void OnKeyboardCharInput(KeyboardCharEventArgs args)
+        protected virtual void OnKeyboardCharInput(TextInputEventArgs args)
         {
             KeyboardCharInput?.Invoke(this, args);
         }
@@ -1014,13 +1059,10 @@
         internal void ProcessEvent(SDLWindowEvent evnt)
         {
             Logger.ThrowIf(destroyed, "The window is already destroyed");
-            SDLWindowEventID type = (SDLWindowEventID)evnt.Event;
+            SDLEventType type = (SDLEventType)evnt.Type;
             switch (type)
             {
-                case SDLWindowEventID.None:
-                    return;
-
-                case SDLWindowEventID.Shown:
+                case SDLEventType.WindowShown:
                     {
                         state = WindowState.Normal;
                         shownEventArgs.Timestamp = evnt.Timestamp;
@@ -1033,7 +1075,7 @@
                     }
                     break;
 
-                case SDLWindowEventID.Hidden:
+                case SDLEventType.WindowHidden:
                     {
                         WindowState oldState = state;
                         state = WindowState.Hidden;
@@ -1049,7 +1091,7 @@
                     }
                     break;
 
-                case SDLWindowEventID.Exposed:
+                case SDLEventType.WindowExposed:
                     {
                         exposedEventArgs.Timestamp = evnt.Timestamp;
                         exposedEventArgs.Handled = false;
@@ -1057,7 +1099,7 @@
                     }
                     break;
 
-                case SDLWindowEventID.Moved:
+                case SDLEventType.WindowMoved:
                     {
                         int xold = x;
                         int yold = y;
@@ -1077,7 +1119,7 @@
                     }
                     break;
 
-                case SDLWindowEventID.Resized:
+                case SDLEventType.WindowResized:
                     {
                         int widthOld = width;
                         int heightOld = height;
@@ -1098,7 +1140,7 @@
                     }
                     break;
 
-                case SDLWindowEventID.SizeChanged:
+                case SDLEventType.WindowPixelSizeChanged:
                     {
                         int widthOld = width;
                         int heightOld = height;
@@ -1115,7 +1157,7 @@
                     }
                     break;
 
-                case SDLWindowEventID.Minimized:
+                case SDLEventType.WindowMinimized:
                     {
                         WindowState oldState = state;
                         state = WindowState.Minimized;
@@ -1131,7 +1173,7 @@
                     }
                     break;
 
-                case SDLWindowEventID.Maximized:
+                case SDLEventType.WindowMaximized:
                     {
                         WindowState oldState = state;
                         state = WindowState.Maximized;
@@ -1147,7 +1189,7 @@
                     }
                     break;
 
-                case SDLWindowEventID.Restored:
+                case SDLEventType.WindowRestored:
                     {
                         WindowState oldState = state;
                         state = WindowState.Normal;
@@ -1163,7 +1205,7 @@
                     }
                     break;
 
-                case SDLWindowEventID.Enter:
+                case SDLEventType.WindowMouseEnter:
                     {
                         hovering = true;
                         enterEventArgs.Timestamp = evnt.Timestamp;
@@ -1172,7 +1214,7 @@
                     }
                     break;
 
-                case SDLWindowEventID.Leave:
+                case SDLEventType.WindowMouseLeave:
                     {
                         hovering = false;
                         leaveEventArgs.Timestamp = evnt.Timestamp;
@@ -1181,7 +1223,7 @@
                     }
                     break;
 
-                case SDLWindowEventID.FocusGained:
+                case SDLEventType.WindowFocusGained:
                     {
                         focused = true;
                         focusGainedEventArgs.Timestamp = evnt.Timestamp;
@@ -1190,7 +1232,7 @@
                     }
                     break;
 
-                case SDLWindowEventID.FocusLost:
+                case SDLEventType.WindowFocusLost:
                     {
                         focused = false;
                         focusLostEventArgs.Timestamp = evnt.Timestamp;
@@ -1199,7 +1241,7 @@
                     }
                     break;
 
-                case SDLWindowEventID.Close:
+                case SDLEventType.WindowCloseRequested:
                     {
                         closeEventArgs.Timestamp = evnt.Timestamp;
                         closeEventArgs.Handled = false;
@@ -1211,19 +1253,7 @@
                     }
                     break;
 
-                case SDLWindowEventID.TakeFocus:
-                    {
-                        takeFocusEventArgs.Timestamp = evnt.Timestamp;
-                        takeFocusEventArgs.Handled = false;
-                        OnTakeFocus(takeFocusEventArgs);
-                        if (!takeFocusEventArgs.Handled)
-                        {
-                            SDL.SetWindowInputFocus(window).SdlThrowIf();
-                        }
-                    }
-                    break;
-
-                case SDLWindowEventID.HitTest:
+                case SDLEventType.WindowHitTest:
                     {
                         hitTestEventArgs.Timestamp = evnt.Timestamp;
                         hitTestEventArgs.Handled = false;
@@ -1240,13 +1270,13 @@
         internal void ProcessInputKeyboard(SDLKeyboardEvent evnt)
         {
             Logger.ThrowIf(destroyed, "The window is already destroyed");
-            KeyState state = (KeyState)evnt.State;
-            Key keyCode = (Key)SDL.GetKeyFromScancode(evnt.Keysym.Scancode);
+            KeyState state = (KeyState)evnt.Down;
+            Key keyCode = (Key)evnt.Key;
             keyboardEventArgs.Timestamp = evnt.Timestamp;
             keyboardEventArgs.Handled = false;
             keyboardEventArgs.State = state;
             keyboardEventArgs.KeyCode = keyCode;
-            keyboardEventArgs.ScanCode = (ScanCode)evnt.Keysym.Scancode;
+            keyboardEventArgs.ScanCode = (ScanCode)evnt.Scancode;
             OnKeyboardInput(keyboardEventArgs);
         }
 
@@ -1259,7 +1289,7 @@
             Logger.ThrowIf(destroyed, "The window is already destroyed");
             keyboardCharEventArgs.Timestamp = evnt.Timestamp;
             keyboardCharEventArgs.Handled = false;
-            keyboardCharEventArgs.Char = (char)evnt.Text_0;
+            keyboardCharEventArgs.Text = evnt.Text;
             OnKeyboardCharInput(keyboardCharEventArgs);
         }
 
@@ -1270,7 +1300,7 @@
         internal void ProcessInputMouse(SDLMouseButtonEvent evnt)
         {
             Logger.ThrowIf(destroyed, "The window is already destroyed");
-            MouseButtonState state = (MouseButtonState)evnt.State;
+            MouseButtonState state = (MouseButtonState)evnt.Down;
             MouseButton button = (MouseButton)evnt.Button;
             mouseButtonEventArgs.Timestamp = evnt.Timestamp;
             mouseButtonEventArgs.Handled = false;
@@ -1322,8 +1352,8 @@
         {
             Logger.ThrowIf(destroyed, "The window is already destroyed");
             touchMotionEventArgs.Timestamp = evnt.Timestamp;
-            touchMotionEventArgs.TouchDeviceId = evnt.TouchId;
-            touchMotionEventArgs.FingerId = evnt.FingerId;
+            touchMotionEventArgs.TouchDeviceId = evnt.TouchID;
+            touchMotionEventArgs.FingerId = evnt.FingerID;
             touchMotionEventArgs.Pressure = evnt.Pressure;
             touchMotionEventArgs.X = evnt.X;
             touchMotionEventArgs.Y = evnt.Y;
@@ -1336,8 +1366,8 @@
         {
             Logger.ThrowIf(destroyed, "The window is already destroyed");
             touchEventArgs.Timestamp = evnt.Timestamp;
-            touchEventArgs.TouchDeviceId = evnt.TouchId;
-            touchEventArgs.FingerId = evnt.FingerId;
+            touchEventArgs.TouchDeviceId = evnt.TouchID;
+            touchEventArgs.FingerId = evnt.FingerID;
             touchEventArgs.Pressure = evnt.Pressure;
             touchEventArgs.X = evnt.X;
             touchEventArgs.Y = evnt.Y;
@@ -1349,8 +1379,8 @@
         {
             Logger.ThrowIf(destroyed, "The window is already destroyed");
             touchEventArgs.Timestamp = evnt.Timestamp;
-            touchEventArgs.TouchDeviceId = evnt.TouchId;
-            touchEventArgs.FingerId = evnt.FingerId;
+            touchEventArgs.TouchDeviceId = evnt.TouchID;
+            touchEventArgs.FingerId = evnt.FingerID;
             touchEventArgs.Pressure = evnt.Pressure;
             touchEventArgs.X = evnt.X;
             touchEventArgs.Y = evnt.Y;
@@ -1379,9 +1409,9 @@
 
             if (cursors != null)
             {
-                for (SDLSystemCursor i = 0; i < SDLSystemCursor.NumSystemCursors; i++)
+                for (SDLSystemCursor i = 0; i < SDLSystemCursor.Count; i++)
                 {
-                    SDL.FreeCursor(cursors[(int)i]);
+                    SDL.DestroyCursor(cursors[(int)i]);
                 }
                 Free(cursors);
                 cursors = null;

--- a/Hexa.NET.KittyUI/Windows/Display.cs
+++ b/Hexa.NET.KittyUI/Windows/Display.cs
@@ -1,101 +1,207 @@
 ﻿namespace Hexa.NET.KittyUI.Windows
 {
-    using Hexa.NET.SDL2;
+    using Hexa.NET.Mathematics;
+    using Hexa.NET.SDL3;
+    using System.Collections.Concurrent;
 
-    public static unsafe class Display
+    public static unsafe class Displays
     {
-        public static int NumVideoDisplays => SDL.GetNumVideoDisplays();
+        private static readonly ConcurrentDictionary<uint, Display> idToDisplay = new();
+        private static readonly List<Display> displays = [];
 
-        public static DisplayMode GetClosestDisplayMode(int displayIndex, DisplayMode mode)
+        internal static void Init()
         {
-            DisplayMode closest;
-            SDL.GetClosestDisplayMode(displayIndex, (SDLDisplayMode*)&mode, (SDLDisplayMode*)&closest);
+            int displayCount;
+            uint* sdlDisplays = SDL.GetDisplays(&displayCount);
+            for (int i = 0; i < displayCount; i++)
+            {
+                uint id = sdlDisplays[i];
+                AddDisplay(id);
+            }
+        }
+
+        private static void AddDisplay(uint id)
+        {
+            Display display = new(id);
+            displays.Add(display);
+            idToDisplay[id] = display;
+        }
+
+        private static void RemoveDisplay(uint id)
+        {
+            if (idToDisplay.TryRemove(id, out var display))
+            {
+                displays.Remove(display);
+            }
+        }
+
+        /// <summary>
+        /// Gets the index of the display containing a specific point on the screen.
+        /// </summary>
+        /// <param name="x">The x-coordinate of the point.</param>
+        /// <param name="y">The y-coordinate of the point.</param>
+        /// <returns>The index of the display containing the point.</returns>
+        public static Display GetDisplayForPoint(int x, int y)
+        {
+            var point = new SDLPoint(x, y);
+            return idToDisplay[SDL.GetDisplayForPoint(&point)];
+        }
+
+        /// <summary>
+        /// Gets the index of the display containing a specific rectangle on the screen.
+        /// </summary>
+        /// <param name="x">The x-coordinate of the rectangle's top-left corner.</param>
+        /// <param name="y">The y-coordinate of the rectangle's top-left corner.</param>
+        /// <param name="width">The width of the rectangle.</param>
+        /// <param name="height">The height of the rectangle.</param>
+        /// <returns>The index of the display containing the rectangle.</returns>
+        public static Display GetDisplayForRect(int x, int y, int width, int height)
+        {
+            var rect = new SDLRect(x, y, width, height);
+            return idToDisplay[SDL.GetDisplayForRect(&rect)];
+        }
+
+        /// <summary>
+        /// Gets the index of the display on which a window resides.
+        /// </summary>
+        /// <param name="window">The window.</param>
+        /// <returns>The index of the display containing the window.</returns>
+        public static Display GetDisplayForWindow(CoreWindow window)
+        {
+            return idToDisplay[SDL.GetDisplayForWindow(window.GetWindow())];
+        }
+
+        internal static void ProcessEvent(SDLDisplayEvent evnt)
+        {
+            switch (evnt.Type)
+            {
+                case SDLEventType.DisplayOrientation:
+                    break;
+
+                case SDLEventType.DisplayAdded:
+                    AddDisplay(evnt.DisplayID);
+                    break;
+
+                case SDLEventType.DisplayRemoved:
+                    RemoveDisplay(evnt.DisplayID);
+                    break;
+
+                case SDLEventType.DisplayMoved:
+                    break;
+
+                case SDLEventType.DisplayDesktopModeChanged:
+                    break;
+
+                case SDLEventType.DisplayCurrentModeChanged:
+                    break;
+
+                case SDLEventType.DisplayContentScaleChanged:
+                    break;
+            }
+        }
+    }
+
+    public unsafe class Display
+    {
+        private readonly uint id;
+
+        public Display(uint id)
+        {
+            this.id = id;
+        }
+
+        protected uint Props => SDL.GetDisplayProperties(id);
+
+        public uint Id => id;
+
+        /// <summary>
+        /// Gets the name of a display.
+        /// </summary>
+        public string Name => SDL.GetDisplayNameS(id);
+
+        /// <summary>
+        /// Gets the current display mode.
+        /// </summary>
+        public DisplayMode CurrentDisplayMode => *SDL.GetCurrentDisplayMode(id);
+
+        /// <summary>
+        /// Gets the desktop display mode for a given display.
+        /// </summary>
+        public DisplayMode DesktopDisplayMode => *SDL.GetDesktopDisplayMode(id);
+
+        /// <summary>
+        /// Gets the current orientation of a display.
+        /// </summary>
+        public DisplayOrientation CurrentOrientation => (DisplayOrientation)SDL.GetCurrentDisplayOrientation(id);
+
+        /// <summary>
+        /// Gets the natural orientation of a display.
+        /// </summary>
+        public DisplayOrientation NaturalOrientation => (DisplayOrientation)SDL.GetNaturalDisplayOrientation(id);
+
+        public bool IsHDREnabled => SDL.HasProperty(Props, SDL.SDL_PROP_DISPLAY_HDR_ENABLED_BOOLEAN);
+
+        /// <summary>
+        /// Gets the bounds of a display in screen coordinates.
+        /// </summary>
+        public Rectangle Bounds
+        {
+            get
+            {
+                SDLRect rectangle;
+                SDL.GetDisplayBounds(id, &rectangle);
+                Rectangle rect;
+                rect.Left = rectangle.X;
+                rect.Top = rectangle.Y;
+                rect.Right = rectangle.X + rectangle.W;
+                rect.Bottom = rectangle.Y + rectangle.H;
+                return rect;
+            }
+        }
+
+        /// <summary>
+        /// Gets the bounds of a display in screen coordinates.
+        /// </summary>
+        public Rectangle UsableBounds
+        {
+            get
+            {
+                SDLRect rectangle;
+                SDL.GetDisplayUsableBounds(id, &rectangle);
+                Rectangle rect;
+                rect.Left = rectangle.X;
+                rect.Top = rectangle.Y;
+                rect.Right = rectangle.X + rectangle.W;
+                rect.Bottom = rectangle.Y + rectangle.H;
+                return rect;
+            }
+        }
+
+        /// <summary>
+        /// Gets the closest display mode to the specified mode for a given display.
+        /// </summary>
+        /// <param name="w"></param>
+        /// <param name="h"></param>
+        /// <param name="refreshRate"></param>
+        /// <param name="includeHighDensityModes"></param>
+        /// <returns>The closest display mode available.</returns>
+        public DisplayMode GetClosestDisplayMode(int w, int h, float refreshRate, bool includeHighDensityModes)
+        {
+            SDLDisplayMode closest;
+            SDL.GetClosestFullscreenDisplayMode(id, w, h, refreshRate, includeHighDensityModes, &closest);
             return closest;
         }
 
-        public static DisplayMode GetCurrentDisplayMode(int displayIndex)
+        public DisplayMode[] GetFullscreenDisplayModes()
         {
-            DisplayMode mode;
-            SDL.GetCurrentDisplayMode(displayIndex, (SDLDisplayMode*)&mode);
-            return mode;
-        }
-
-        public static DisplayMode GetDesktopDisplayMode(int displayIndex)
-        {
-            DisplayMode mode;
-            SDL.GetDesktopDisplayMode(displayIndex, (SDLDisplayMode*)&mode);
-            return mode;
-        }
-
-        public static string GetDisplayName(int displayIndex)
-        {
-            return SDL.GetDisplayNameS(displayIndex);
-        }
-
-        public static DisplayOrientation GetDisplayOrientation(int displayIndex)
-        {
-            return (DisplayOrientation)SDL.GetDisplayOrientation(displayIndex);
-        }
-
-        public static void GetDisplayDPI(int displayIndex, ref float ddpi, ref float hdpi, ref float vdpi)
-        {
-            SDL.GetDisplayDPI(displayIndex, ref ddpi, ref hdpi, ref vdpi);
-        }
-
-        public static void GetDisplayBounds(int displayIndex, ref int x, ref int y, ref int width, ref int height)
-        {
-            SDLRect rectangle;
-            SDL.GetDisplayBounds(displayIndex, &rectangle);
-            x = rectangle.X;
-            y = rectangle.Y;
-            width = rectangle.W;
-            height = rectangle.H;
-        }
-
-        public static void GetDisplayUsableBounds(int displayIndex, ref int x, ref int y, ref int width, ref int height)
-        {
-            SDLRect rectangle;
-            SDL.GetDisplayUsableBounds(displayIndex, &rectangle);
-            x = rectangle.X;
-            y = rectangle.Y;
-            width = rectangle.W;
-            height = rectangle.H;
-        }
-
-        public static DisplayMode GetDisplayMode(int displayIndex, int modeIndex)
-        {
-            DisplayMode mode;
-            SDL.GetDisplayMode(displayIndex, modeIndex, (SDLDisplayMode*)&mode);
-            return mode;
-        }
-
-        public static int GetNumDisplayModes(int displayIndex)
-        {
-            return SDL.GetNumDisplayModes(displayIndex);
-        }
-
-        public static int GetPointDisplayIndex(int x, int y)
-        {
-            var point = new SDLPoint(x, y);
-            return SDL.GetPointDisplayIndex(ref point);
-        }
-
-        public static int GetRectDisplayIndex(int x, int y, int width, int height)
-        {
-            var rect = new SDLRect(x, y, width, height);
-            return SDL.GetRectDisplayIndex(ref rect);
-        }
-
-        public static int GetWindowDisplayIndex(CoreWindow window)
-        {
-            return SDL.GetWindowDisplayIndex(window.GetWindow());
-        }
-
-        public static DisplayMode GetWindowDisplayMode(CoreWindow window)
-        {
-            DisplayMode mode;
-            SDL.GetWindowDisplayMode(window.GetWindow(), (SDLDisplayMode*)&mode);
-            return mode;
+            int modeCount;
+            SDLDisplayMode** modes = SDL.GetFullscreenDisplayModes(id, &modeCount);
+            DisplayMode[] result = new DisplayMode[modeCount];
+            for (int i = 0; i < modeCount; i++)
+            {
+                result[i] = *modes[i];
+            }
+            return result;
         }
     }
 }

--- a/Hexa.NET.KittyUI/Windows/DisplayInfo.cs
+++ b/Hexa.NET.KittyUI/Windows/DisplayInfo.cs
@@ -1,11 +1,119 @@
 ﻿namespace Hexa.NET.KittyUI.Windows
 {
-    public struct DisplayMode
+    using Hexa.NET.SDL3;
+    using System;
+
+    /// <summary>
+    /// Represents a display mode, which specifies the format, width, height, refresh rate, and driver data of a display.
+    /// </summary>
+    public unsafe struct DisplayMode : IEquatable<DisplayMode>
     {
-        public uint Format;
+        public uint DisplayID;
+
+        /// <summary>
+        /// The pixel format of the display mode.
+        /// </summary>
+        public DisplayPixelFormat Format;
+
+        /// <summary>
+        /// The width of the display mode in pixels.
+        /// </summary>
         public int W;
+
+        /// <summary>
+        /// The height of the display mode in pixels.
+        /// </summary>
         public int H;
-        public int RefreshRate;
-        public unsafe void* DriverData;
+
+        public float PixelDensity;
+
+        /// <summary>
+        /// The refresh rate of the display mode in Hz.
+        /// </summary>
+        public float RefreshRate;
+
+        public int RefreshRateNumerator;
+
+        public int RefreshRateDenominator;
+
+        /// <summary>
+        /// A pointer to driver-specific data associated with the display mode.
+        /// </summary>
+        private void* Internal;
+
+        public override readonly bool Equals(object? obj)
+        {
+            return obj is DisplayMode mode && Equals(mode);
+        }
+
+        public readonly bool Equals(DisplayMode other)
+        {
+            return DisplayID == other.DisplayID &&
+                   Format == other.Format &&
+                   W == other.W &&
+                   H == other.H &&
+                   PixelDensity == other.PixelDensity &&
+                   RefreshRate == other.RefreshRate &&
+                   RefreshRateNumerator == other.RefreshRateNumerator &&
+                   RefreshRateDenominator == other.RefreshRateDenominator &&
+                   Internal == other.Internal;
+        }
+
+        public override readonly int GetHashCode()
+        {
+            HashCode hash = new();
+            hash.Add(DisplayID);
+            hash.Add(Format);
+            hash.Add(W);
+            hash.Add(H);
+            hash.Add(PixelDensity);
+            hash.Add(RefreshRate);
+            hash.Add(RefreshRateNumerator);
+            hash.Add(RefreshRateDenominator);
+            hash.Add((nint)Internal);
+            return hash.ToHashCode();
+        }
+
+        public static bool operator ==(DisplayMode left, DisplayMode right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(DisplayMode left, DisplayMode right)
+        {
+            return !(left == right);
+        }
+
+        public static implicit operator DisplayMode(SDLDisplayMode mode)
+        {
+            return new()
+            {
+                DisplayID = mode.DisplayID,
+                Format = (DisplayPixelFormat)mode.Format,
+                W = mode.W,
+                H = mode.H,
+                PixelDensity = mode.PixelDensity,
+                RefreshRate = mode.RefreshRate,
+                RefreshRateNumerator = mode.RefreshRateNumerator,
+                RefreshRateDenominator = mode.RefreshRateDenominator,
+                Internal = mode.Internal
+            };
+        }
+
+        public static implicit operator SDLDisplayMode(DisplayMode mode)
+        {
+            return new()
+            {
+                DisplayID = mode.DisplayID,
+                Format = (SDLPixelFormat)mode.Format,
+                W = mode.W,
+                H = mode.H,
+                PixelDensity = mode.PixelDensity,
+                RefreshRate = mode.RefreshRate,
+                RefreshRateNumerator = mode.RefreshRateNumerator,
+                RefreshRateDenominator = mode.RefreshRateDenominator,
+                Internal = (SDLDisplayModeData*)mode.Internal
+            };
+        }
     }
 }

--- a/Hexa.NET.KittyUI/Windows/DisplayPixelFormat.cs
+++ b/Hexa.NET.KittyUI/Windows/DisplayPixelFormat.cs
@@ -1,0 +1,360 @@
+﻿namespace Hexa.NET.KittyUI.Windows
+{
+    public enum DisplayPixelFormat
+    {
+        Unknown = 0,
+
+        Index1Lsb = 0x11100100,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_INDEX1, SDL_BITMAPORDER_4321, 0, 1, 0),
+        Index1Msb = 0x11200100,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_INDEX1, SDL_BITMAPORDER_1234, 0, 1, 0),
+        Index2Lsb = 0x1C100200,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_INDEX2, SDL_BITMAPORDER_4321, 0, 2, 0),
+        Index2Msb = 0x1C200200,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_INDEX2, SDL_BITMAPORDER_1234, 0, 2, 0),
+        Index4Lsb = 0x12100400,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_INDEX4, SDL_BITMAPORDER_4321, 0, 4, 0),
+        Index4Msb = 0x12200400,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_INDEX4, SDL_BITMAPORDER_1234, 0, 4, 0),
+        Index8 = 0x13000801,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_INDEX8, 0, 0, 8, 1),
+        Rgb332 = 0x14110801,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED8, SDL_PACKEDORDER_XRGB, SDL_PACKEDLAYOUT_332,
+        //     8, 1),
+        Xrgb4444 = 0x15120C02,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_XRGB, SDL_PACKEDLAYOUT_4444,
+        //     12, 2),
+        Xbgr4444 = 0x15520C02,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_XBGR, SDL_PACKEDLAYOUT_4444,
+        //     12, 2),
+        Xrgb1555 = 0x15130F02,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_XRGB, SDL_PACKEDLAYOUT_1555,
+        //     15, 2),
+        Xbgr1555 = 0x15530F02,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_XBGR, SDL_PACKEDLAYOUT_1555,
+        //     15, 2),
+        Argb4444 = 0x15321002,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_ARGB, SDL_PACKEDLAYOUT_4444,
+        //     16, 2),
+        Rgba4444 = 0x15421002,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_RGBA, SDL_PACKEDLAYOUT_4444,
+        //     16, 2),
+        Abgr4444 = 0x15721002,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_ABGR, SDL_PACKEDLAYOUT_4444,
+        //     16, 2),
+        Bgra4444 = 0x15821002,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_BGRA, SDL_PACKEDLAYOUT_4444,
+        //     16, 2),
+        Argb1555 = 0x15331002,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_ARGB, SDL_PACKEDLAYOUT_1555,
+        //     16, 2),
+        Rgba5551 = 0x15441002,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_RGBA, SDL_PACKEDLAYOUT_5551,
+        //     16, 2),
+        Abgr1555 = 0x15731002,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_ABGR, SDL_PACKEDLAYOUT_1555,
+        //     16, 2),
+        Bgra5551 = 0x15841002,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_BGRA, SDL_PACKEDLAYOUT_5551,
+        //     16, 2),
+        Rgb565 = 0x15151002,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_XRGB, SDL_PACKEDLAYOUT_565,
+        //     16, 2),
+        Bgr565 = 0x15551002,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED16, SDL_PACKEDORDER_XBGR, SDL_PACKEDLAYOUT_565,
+        //     16, 2),
+        Rgb24 = 0x17101803,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYU8, SDL_ARRAYORDER_RGB, 0, 24, 3),
+        Bgr24 = 0x17401803,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYU8, SDL_ARRAYORDER_BGR, 0, 24, 3),
+        Xrgb8888 = 0x16161804,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_XRGB, SDL_PACKEDLAYOUT_8888,
+        //     24, 4),
+        Rgbx8888 = 0x16261804,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_RGBX, SDL_PACKEDLAYOUT_8888,
+        //     24, 4),
+        Xbgr8888 = 0x16561804,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_XBGR, SDL_PACKEDLAYOUT_8888,
+        //     24, 4),
+        Bgrx8888 = 0x16661804,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_BGRX, SDL_PACKEDLAYOUT_8888,
+        //     24, 4),
+        Argb8888 = 0x16362004,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_ARGB, SDL_PACKEDLAYOUT_8888,
+        //     32, 4),
+        Rgba8888 = 0x16462004,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_RGBA, SDL_PACKEDLAYOUT_8888,
+        //     32, 4),
+        Abgr8888 = 0x16762004,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_ABGR, SDL_PACKEDLAYOUT_8888,
+        //     32, 4),
+        Bgra8888 = 0x16862004,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_BGRA, SDL_PACKEDLAYOUT_8888,
+        //     32, 4),
+        Xrgb2101010 = 0x16172004,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_XRGB, SDL_PACKEDLAYOUT_2101010,
+        //     32, 4),
+        Xbgr2101010 = 0x16572004,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_XBGR, SDL_PACKEDLAYOUT_2101010,
+        //     32, 4),
+        Argb2101010 = 0x16372004,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_ARGB, SDL_PACKEDLAYOUT_2101010,
+        //     32, 4),
+        Abgr2101010 = 0x16772004,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_PACKED32, SDL_PACKEDORDER_ABGR, SDL_PACKEDLAYOUT_2101010,
+        //     32, 4),
+        Rgb48 = 0x18103006,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYU16, SDL_ARRAYORDER_RGB, 0, 48, 6),
+        Bgr48 = 0x18403006,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYU16, SDL_ARRAYORDER_BGR, 0, 48, 6),
+        Rgba64 = 0x18204008,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYU16, SDL_ARRAYORDER_RGBA, 0, 64, 8),
+        Argb64 = 0x18304008,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYU16, SDL_ARRAYORDER_ARGB, 0, 64, 8),
+        Bgra64 = 0x18504008,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYU16, SDL_ARRAYORDER_BGRA, 0, 64, 8),
+        Abgr64 = 0x18604008,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYU16, SDL_ARRAYORDER_ABGR, 0, 64, 8),
+        Rgb48Float = 0x1A103006,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYF16, SDL_ARRAYORDER_RGB, 0, 48, 6),
+        Bgr48Float = 0x1A403006,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYF16, SDL_ARRAYORDER_BGR, 0, 48, 6),
+        Rgba64Float = 0x1A204008,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYF16, SDL_ARRAYORDER_RGBA, 0, 64, 8),
+        Argb64Float = 0x1A304008,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYF16, SDL_ARRAYORDER_ARGB, 0, 64, 8),
+        Bgra64Float = 0x1A504008,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYF16, SDL_ARRAYORDER_BGRA, 0, 64, 8),
+        Abgr64Float = 0x1A604008,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYF16, SDL_ARRAYORDER_ABGR, 0, 64, 8),
+        Rgb96Float = 0x1B10600C,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYF32, SDL_ARRAYORDER_RGB, 0, 96, 12),
+        Bgr96Float = 0x1B40600C,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYF32, SDL_ARRAYORDER_BGR, 0, 96, 12),
+        Rgba128Float = 0x1B208010,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYF32, SDL_ARRAYORDER_RGBA, 0, 128, 16),
+        Argb128Float = 0x1B308010,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYF32, SDL_ARRAYORDER_ARGB, 0, 128, 16),
+        Bgra128Float = 0x1B508010,
+
+        //
+        // Summary:
+        //     SDL_DEFINE_PIXELFORMAT(SDL_PIXELTYPE_ARRAYF32, SDL_ARRAYORDER_BGRA, 0, 128, 16),
+        Abgr128Float = 0x1B608010,
+
+        //
+        // Summary:
+        //     Planar mode: Y + V + U (3 planes)
+        Yv12 = 0x32315659,
+
+        //
+        // Summary:
+        //     Planar mode: Y + U + V (3 planes)
+        Iyuv = 0x56555949,
+
+        //
+        // Summary:
+        //     Packed mode: Y0+U0+Y1+V0 (1 plane)
+        Yuy2 = 0x32595559,
+
+        //
+        // Summary:
+        //     Packed mode: U0+Y0+V0+Y1 (1 plane)
+        Uyvy = 0x59565955,
+
+        //
+        // Summary:
+        //     Packed mode: Y0+V0+Y1+U0 (1 plane)
+        Yvyu = 0x55595659,
+
+        //
+        // Summary:
+        //     Planar mode: Y + U/V interleaved (2 planes)
+        Nv12 = 0x3231564E,
+
+        //
+        // Summary:
+        //     Planar mode: Y + V/U interleaved (2 planes)
+        Nv21 = 0x3132564E,
+
+        //
+        // Summary:
+        //     Planar mode: Y + U/V interleaved (2 planes)
+        P010 = 0x30313050,
+
+        //
+        // Summary:
+        //     Android video texture format
+        ExternalOes = 0x2053454F,
+
+        //
+        // Summary:
+        //     Motion JPEG
+        Mjpg = 0x47504A4D,
+
+        Rgba32 = 0x16762004,
+        Argb32 = 0x16862004,
+        Bgra32 = 0x16362004,
+        Abgr32 = 0x16462004,
+        Rgbx32 = 0x16561804,
+        Xrgb32 = 0x16661804,
+        Bgrx32 = 0x16161804,
+        Xbgr32 = 0x16261804
+    }
+}

--- a/Hexa.NET.KittyUI/Windows/Events/TimestampEventArgs.cs
+++ b/Hexa.NET.KittyUI/Windows/Events/TimestampEventArgs.cs
@@ -9,6 +9,6 @@
         /// <summary>
         /// Gets the timestamp of an event.
         /// </summary>
-        public uint Timestamp { get; internal set; }
+        public ulong Timestamp { get; internal set; }
     }
 }

--- a/Hexa.NET.KittyUI/Windows/IWindow.cs
+++ b/Hexa.NET.KittyUI/Windows/IWindow.cs
@@ -146,7 +146,7 @@
         /// <summary>
         /// Event triggered when a character input is received from the keyboard.
         /// </summary>
-        event EventHandler<KeyboardCharEventArgs>? KeyboardCharInput;
+        event EventHandler<TextInputEventArgs>? KeyboardCharInput;
 
         /// <summary>
         /// Event triggered when a keyboard input is received.
@@ -266,7 +266,7 @@
         /// Gets the underlying native window pointer.
         /// </summary>
         /// <returns>A pointer to the native window.</returns>
-        unsafe SDL2.SDLWindow* GetWindow();
+        unsafe SDL3.SDLWindow* GetWindow();
 
         /// <summary>
         /// Clears the input state for the window.

--- a/Hexa.NET.KittyUI/Windows/SdlContext.cs
+++ b/Hexa.NET.KittyUI/Windows/SdlContext.cs
@@ -1,7 +1,7 @@
 ﻿namespace Hexa.NET.KittyUI.Windows
 {
     using Hexa.NET.Mathematics;
-    using Hexa.NET.SDL2;
+    using Hexa.NET.SDL3;
     using HexaGen.Runtime;
 
     public unsafe class SdlContext : IGLContext
@@ -36,7 +36,7 @@
             get
             {
                 var ret = stackalloc int[2];
-                SDL.GLGetDrawableSize(Window, ret, &ret[1]);
+                SDL.GetWindowSizeInPixels(Window, ret, &ret[1]);
                 return *(Point2*)ret;
             }
         }
@@ -45,7 +45,7 @@
         {
             if (_ctx != default)
             {
-                SDL.GLDeleteContext(_ctx);
+                SDL.GLDestroyContext(_ctx);
                 _ctx = default;
             }
         }
@@ -114,7 +114,7 @@
 
         public bool IsExtensionSupported(string extensionName)
         {
-            return SDL.GLExtensionSupported(extensionName) == SDLBool.True;
+            return SDL.GLExtensionSupported(extensionName) == true;
         }
     }
 }

--- a/Hexa.NET.KittyUI/Windows/Window.cs
+++ b/Hexa.NET.KittyUI/Windows/Window.cs
@@ -13,10 +13,8 @@
     using Hexa.NET.ImGui;
     using Hexa.NET.ImGui.Backends.D3D11;
     using Hexa.NET.ImGui.Backends.OpenGL3;
-    using Hexa.NET.ImGui.Backends.SDL2;
     using Hexa.NET.ImGui.Widgets;
     using Hexa.NET.KittyUI;
-    using Hexa.NET.KittyUI.Audio;
     using Hexa.NET.KittyUI.D3D11;
     using Hexa.NET.KittyUI.Debugging;
     using Hexa.NET.KittyUI.ImGuiBackend;
@@ -30,9 +28,7 @@
     using Hexa.NET.KittyUI.Graphics;
     using Hexa.NET.D3D11;
     using Hexa.NET.Logging;
-    using HexaGen.Runtime;
-    using System.Diagnostics;
-    using System.Runtime.CompilerServices;
+    using Hexa.NET.ImGui.Backends.SDL3;
 
     public class Window : CoreWindow, IRenderWindow
     {
@@ -75,8 +71,8 @@
                     var ctx = D3D11GraphicsDevice.DeviceContext;
                     imGuiRenderer = new(appBuilder, ImGuiImplD3D11.NewFrame, ImGuiImplD3D11.RenderDrawData);
                     context = ImGui.GetCurrentContext();
-                    ImGuiImplSDL2.SetCurrentContext(context);
-                    ImGuiImplSDL2.InitForD3D((SDLWindow*)GetWindow());
+                    ImGuiImplSDL3.SetCurrentContext(context);
+                    ImGuiImplSDL3.SDL3InitForD3D((SDLWindow*)GetWindow());
                     ImGuiImplD3D11.SetCurrentContext(context);
                     ImGuiImplD3D11.Init((NET.ImGui.Backends.D3D11.ID3D11Device*)dev.Handle, (NET.ImGui.Backends.D3D11.ID3D11DeviceContext*)ctx.Handle);
                     break;
@@ -84,8 +80,8 @@
                 case GraphicsBackend.OpenGL:
                     imGuiRenderer = new(appBuilder, ImGuiImplOpenGL3.NewFrame, ImGuiImplOpenGL3.RenderDrawData);
                     context = ImGui.GetCurrentContext();
-                    ImGuiImplSDL2.SetCurrentContext(context);
-                    ImGuiImplSDL2.InitForOpenGL((SDLWindow*)GetWindow(), (void*)GLContext.Handle);
+                    ImGuiImplSDL3.SetCurrentContext(context);
+                    ImGuiImplSDL3.SDL3InitForOpenGL((SDLWindow*)GetWindow(), (void*)GLContext.Handle);
                     ImGuiImplOpenGL3.SetCurrentContext(context);
                     ImGuiImplOpenGL3.Init((byte*)null);
                     break;
@@ -98,9 +94,9 @@
             OnRendererInitialize();
         }
 
-        private unsafe bool SDLEventHook(SDL2.SDLEvent evnt)
+        private unsafe bool SDLEventHook(SDL3.SDLEvent evnt)
         {
-            return ImGuiImplSDL2.ProcessEvent((SDLEvent*)&evnt);
+            return ImGuiImplSDL3.SDL3ProcessEvent((SDLEvent*)&evnt);
         }
 
         public virtual void Render()
@@ -230,20 +226,23 @@
 
             WidgetManager.Dispose();
             renderDispatcher.Dispose();
-          
+
 
             switch (Backend)
             {
                 case GraphicsBackend.D3D11:
                     ImGuiImplD3D11.Shutdown();
+                    ImGuiImplD3D11.SetCurrentContext(null);
                     break;
 
                 case GraphicsBackend.OpenGL:
                     ImGuiImplOpenGL3.Shutdown();
+                    ImGuiImplOpenGL3.SetCurrentContext(null);
                     break;
             }
 
-            ImGuiImplSDL2.Shutdown();
+            ImGuiImplSDL3.SDL3Shutdown();
+            ImGuiImplSDL3.SetCurrentContext(null);
 
             imGuiRenderer?.Dispose();
         }


### PR DESCRIPTION
This PR transitions the codebase from `Hexa.NET.SDL2` to `Hexa.NET.SDL3`, updating all relevant classes and methods to align with the new SDL3 API. Key changes include the introduction of new structures like `PowerInfo` and `PowerState` for joystick power management, enhancements to the `DisplayMode` structure, and improvements in the `CoreWindow` class for better window handling. Additionally, the `Gamepad`, `Joystick`, `Clipboard`, `Mouse`, and `TouchDevice` classes have been refactored to ensure consistent input and event handling. The project file has also been updated to reference the new SDL3 packages, ensuring proper dependencies for building the project.